### PR TITLE
refactor : 인기글 조회 로직 개선, 크롤링한 공지사항 게시글 시간 설정 변경

### DIFF
--- a/src/main/java/com/example/ajouevent/repository/EventRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/EventRepository.java
@@ -26,7 +26,7 @@ public interface EventRepository extends JpaRepository<ClubEvent, Long> {
 	@Query("SELECT ce FROM ClubEvent ce WHERE ce.eventId IN :eventIds ORDER BY ce.createdAt DESC")
 	Slice<ClubEvent> findByEventIds(@Param("eventIds") List<Long> eventIds, Pageable pageable);
 
-	@Query("SELECT ce FROM ClubEvent ce WHERE ce.createdAt BETWEEN :startOfWeek AND :endOfWeek ORDER BY ce.viewCount DESC")
+	@Query("SELECT ce FROM ClubEvent ce WHERE ce.createdAt BETWEEN :startOfWeek AND :endOfWeek ORDER BY ce.viewCount DESC LIMIT 10")
 	List<ClubEvent> findTop10ByCreatedAtBetweenOrderByViewCountDesc(@Param("startOfWeek") LocalDateTime startOfWeek, @Param("endOfWeek") LocalDateTime endOfWeek);
 
 	@Modifying

--- a/src/main/java/com/example/ajouevent/service/EventService.java
+++ b/src/main/java/com/example/ajouevent/service/EventService.java
@@ -100,7 +100,7 @@ public class EventService {
 		ClubEvent clubEvent = ClubEvent.builder()
 			.title(noticeDto.getTitle())
 			.content(noticeDto.getContent())
-			.createdAt(noticeDto.getDate())
+			.createdAt(LocalDateTime.now()) // 크롤링한 공지사항의 게시글 시간은 크롤링하는 당시 시간으로 설정
 			.url(noticeDto.getUrl())
 			.subject(noticeDto.getKoreanTopic())
 			.writer(noticeDto.getDepartment())


### PR DESCRIPTION
- 크롤링한 공지사항 DB에 저장할 때, 게시글 시간은 크롤링 당시 시간으로 설정(공지사항 날짜 임의 설정 문제)
  교직원분들께서 공지사항을 작성할 때 임의날짜로 작성하는 경우가 있고, 같은 게시글을 여러번 올리는 경우가 있어서 반영 
- 인기글 조회 로직 개선
 메서드 분리, EventRepository에서 인기글 조회하는 쿼리 부분에 LIMIT 10 추가