### PR TITLE
refactor: 사용되지 않는 'isSubscribedTabRead' 필드 및 관련 코드 삭제

### DIFF
--- a/src/main/java/com/example/ajouevent/controller/EventController.java
+++ b/src/main/java/com/example/ajouevent/controller/EventController.java
@@ -219,18 +219,6 @@ public class EventController {
 		return ResponseEntity.ok(eventService.getMemberReadStatus(principal));
 	}
 
-	// 구독 탭 클릭 시 상태 업데이트
-	@PreAuthorize("isAuthenticated()")
-	@PostMapping("/updateSubscribedTabRead")
-	public ResponseEntity<ResponseDto> updateSubscribedTabRead(Principal principal) {
-		eventService.updateSubscribedTabReadStatus(principal);
-		return ResponseEntity.ok().body(ResponseDto.builder()
-			.successStatus(HttpStatus.OK)
-			.successContent("구독 탭의 읽음 상태 업데이트 요청 완료.")
-			.build()
-		);
-	}
-
 	// 구독 알림 클릭 시 상태 업데이트
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping("/updateTopicTabRead")

--- a/src/main/java/com/example/ajouevent/domain/Member.java
+++ b/src/main/java/com/example/ajouevent/domain/Member.java
@@ -55,23 +55,19 @@ public class Member {
 	private List<KeywordMember> keywordMembers;
 
 	@Column(nullable = false)
-	private Boolean isSubscribedTabRead;
-
-	@Column(nullable = false)
 	private Boolean isTopicTabRead;
 
 	@Column(nullable = false)
 	private Boolean isKeywordTabRead;
 
 	@Builder
-	public Member(Long id, String email, String name, String password, String major, String phone, Boolean isSubscribedTabRead, Boolean isTopicTabRead, Boolean isKeywordTabRead) {
+	public Member(Long id, String email, String name, String password, String major, String phone, Boolean isTopicTabRead, Boolean isKeywordTabRead) {
 		this.id = id;
 		this.email = email;
 		this.name = name;
 		this.password = password;
 		this.major = major;
 		this.phone = phone;
-		this.isSubscribedTabRead = isSubscribedTabRead;
 		this.isTopicTabRead = isTopicTabRead;
 		this.isKeywordTabRead = isKeywordTabRead;
 	}

--- a/src/main/java/com/example/ajouevent/dto/MemberReadStatusDto.java
+++ b/src/main/java/com/example/ajouevent/dto/MemberReadStatusDto.java
@@ -8,7 +8,6 @@ import lombok.Setter;
 @Setter
 @Builder
 public class MemberReadStatusDto {
-	private Boolean isSubscribedTabRead;
 	private Boolean isTopicTabRead;
 	private Boolean isKeywordTabRead;
 

--- a/src/main/java/com/example/ajouevent/repository/MemberRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/MemberRepository.java
@@ -35,10 +35,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Member findMemberByEmailAndPhone(String email, String phone);
 
 	@Modifying
-	@Query("UPDATE Member m SET m.isSubscribedTabRead = :isRead WHERE m = :member")
-	void updateSubscribedTabReadStatus(@Param("member") Member member, @Param("isRead") boolean isRead);
-
-	@Modifying
 	@Query("UPDATE Member m SET m.isTopicTabRead = :isRead WHERE m = :member")
 	void updateTopicTabReadStatus(@Param("member") Member member, @Param("isRead") boolean isRead);
 

--- a/src/main/java/com/example/ajouevent/service/EventService.java
+++ b/src/main/java/com/example/ajouevent/service/EventService.java
@@ -1215,24 +1215,10 @@ public class EventService {
 
 		Member member = memberRepository.findByEmail(principal.getName()).orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
 		return MemberReadStatusDto.builder()
-			.isSubscribedTabRead(member.getIsSubscribedTabRead())
 			.isTopicTabRead(member.getIsTopicTabRead())
 			.isKeywordTabRead(member.getIsKeywordTabRead())
 			.build();
 	}
-
-	// 구독 탭 읽음 상태 업데이트 (토픽과 키워드 모두 읽음일 때만 true로 설정)
-	@Transactional
-	public void updateSubscribedTabReadStatus(Principal principal) {
-		Member member = memberRepository.findByEmail(principal.getName()).orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
-
-		// 두 값이 모두 true일 때만 구독 탭 읽음 상태도 true로 설정
-		if (member.getIsTopicTabRead() && member.getIsKeywordTabRead()) {
-			member.setIsSubscribedTabRead(true);
-			memberRepository.save(member); // 업데이트된 상태 저장
-		}
-	}
-
 
 	// 구독 알림 읽음 상태를 관리하기 위한 로직
 	@Transactional

--- a/src/main/java/com/example/ajouevent/service/MemberService.java
+++ b/src/main/java/com/example/ajouevent/service/MemberService.java
@@ -233,7 +233,6 @@ public class MemberService {
 			member = Member.builder()
 				.email(userInfoGetDto.getEmail())
 				.name(userInfoGetDto.getName())
-				.isSubscribedTabRead(true)
 				.isTopicTabRead(true)
 				.isKeywordTabRead(true)
 				.build();


### PR DESCRIPTION
## 💻 작업 내용

> (작업내용작성)

- [x] `Member` 엔티티에서 `isSubscribedTabRead` 필드 제거
- [x] 해당 필드와 관련된 주석 및 API 엔드포인트 삭제
- [x] DTO와 서비스 로직에서 `isSubscribedTabRead`와 관련된 코드 제거

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
