### PR TITLE
feat: 구독탭 읽음 상태 반환하는 api 추가 (#68)

### DIFF
--- a/src/main/java/com/example/ajouevent/controller/SubscriptionController.java
+++ b/src/main/java/com/example/ajouevent/controller/SubscriptionController.java
@@ -1,0 +1,25 @@
+package com.example.ajouevent.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.ajouevent.dto.TabReadStatusResponse;
+import com.example.ajouevent.service.SubscriptionService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/subscriptions")
+@Slf4j
+public class SubscriptionController {
+	private final SubscriptionService subscriptionService;
+
+	@GetMapping("/isSubscribedTabRead")
+	public TabReadStatusResponse isSubscribedTabRead() {
+		return subscriptionService.isSubscribedTabRead();
+	}
+
+}

--- a/src/main/java/com/example/ajouevent/domain/KeywordMember.java
+++ b/src/main/java/com/example/ajouevent/domain/KeywordMember.java
@@ -35,8 +35,8 @@ public class KeywordMember {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	@Column(nullable = false)
-	private Boolean isRead;  // 해당 키워드의 새 공지사항 읽음 여부
+	@Column(nullable = false, columnDefinition = "TINYINT(1)")
+	private boolean isRead;  // 해당 키워드의 새 공지사항 읽음 여부
 
 	@Column(nullable = false)
 	private LocalDateTime lastReadAt;  // 마지막으로 읽은 시각

--- a/src/main/java/com/example/ajouevent/domain/TopicMember.java
+++ b/src/main/java/com/example/ajouevent/domain/TopicMember.java
@@ -35,7 +35,7 @@ public class TopicMember {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	@Column(nullable = false)
+	@Column(nullable = false, columnDefinition = "TINYINT(1)")
 	private boolean isRead;
 
 	@Column(nullable = false)

--- a/src/main/java/com/example/ajouevent/dto/TabReadStatusResponse.java
+++ b/src/main/java/com/example/ajouevent/dto/TabReadStatusResponse.java
@@ -1,0 +1,19 @@
+package com.example.ajouevent.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+public class TabReadStatusResponse {
+	private boolean isSubscribedTabRead;
+
+	@JsonCreator
+	public TabReadStatusResponse(boolean isSubscribedTabRead) {
+		this.isSubscribedTabRead = isSubscribedTabRead;
+	}
+}

--- a/src/main/java/com/example/ajouevent/repository/KeywordMemberRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/KeywordMemberRepository.java
@@ -42,4 +42,6 @@ public interface KeywordMemberRepository extends JpaRepository<KeywordMember, Lo
 	@Modifying
 	@Query("UPDATE KeywordMember km SET km.isRead = :isRead WHERE km.keyword = :keyword AND km.member = :member")
 	void updateReadStatus(@Param("isRead") boolean isRead, @Param("keyword") Keyword keyword, @Param("member") Member member);
+
+	boolean existsByMemberAndIsReadFalse(Member member);
 }

--- a/src/main/java/com/example/ajouevent/repository/TopicMemberRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/TopicMemberRepository.java
@@ -38,4 +38,6 @@ public interface TopicMemberRepository extends JpaRepository<TopicMember, Long> 
 
 	Optional<TopicMember> findByMemberAndTopic(Member member, Topic topic);
 
+	boolean existsByMemberAndIsReadFalse(Member member);
+
 }

--- a/src/main/java/com/example/ajouevent/service/EventService.java
+++ b/src/main/java/com/example/ajouevent/service/EventService.java
@@ -187,7 +187,7 @@ public class EventService {
 
 				// 각 구독자의 읽음 상태를 '읽지 않음'으로 설정
 				for (KeywordMember keywordMember : keywordMembers) {
-					keywordMember.setIsRead(false);  // 읽음 상태를 읽지 않음으로 설정
+					keywordMember.setRead(false);  // 읽음 상태를 읽지 않음으로 설정
 					keywordMember.setLastReadAt(LocalDateTime.now());
 					keywordMemberRepository.save(keywordMember);
 
@@ -1170,8 +1170,8 @@ public class EventService {
 		// 사용자가 구독한 해당 키워드의 읽음 상태를 업데이트
 		KeywordMember keywordMember = keywordMemberRepository.findByKeywordAndMember(keyword, member)
 			.orElseThrow(() -> new CustomException(CustomErrorCode.KEYWORD_NOT_FOUND));
-		if (keywordMember.getIsRead() == false) {
-			keywordMember.setIsRead(true);  // 읽음 상태로 업데이트
+		if (keywordMember.isRead() == false) {
+			keywordMember.setRead(true);  // 읽음 상태로 업데이트
 			keywordMember.setLastReadAt(LocalDateTime.now());  // 마지막으로 읽은 시간 설정
 			keywordMemberRepository.save(keywordMember);  // 업데이트된 읽음 상태 저장
 		}

--- a/src/main/java/com/example/ajouevent/service/KeywordService.java
+++ b/src/main/java/com/example/ajouevent/service/KeywordService.java
@@ -169,7 +169,7 @@ public class KeywordService {
 				.koreanKeyword(km.getKeyword().getKoreanKeyword())
 				.searchKeyword(km.getKeyword().getSearchKeyword())
 				.topicName(km.getKeyword().getTopic().getKoreanTopic())
-				.isRead(km.getIsRead())
+				.isRead(km.isRead())
 				.lastReadAt(km.getLastReadAt())
 				.build())
 			.collect(Collectors.toList());

--- a/src/main/java/com/example/ajouevent/service/SubscriptionService.java
+++ b/src/main/java/com/example/ajouevent/service/SubscriptionService.java
@@ -1,0 +1,41 @@
+package com.example.ajouevent.service;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.ajouevent.domain.Member;
+import com.example.ajouevent.dto.TabReadStatusResponse;
+import com.example.ajouevent.exception.CustomErrorCode;
+import com.example.ajouevent.exception.CustomException;
+import com.example.ajouevent.repository.KeywordMemberRepository;
+import com.example.ajouevent.repository.MemberRepository;
+import com.example.ajouevent.repository.TopicMemberRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SubscriptionService {
+	private final MemberRepository memberRepository;
+	private final TopicMemberRepository topicMemberRepository;
+	private final KeywordMemberRepository keywordMemberRepository;
+
+	@Transactional(readOnly = true)
+	public TabReadStatusResponse isSubscribedTabRead() {
+		String memberEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
+
+		// TopicMember와 KeywordMember에서 isRead가 false인 항목이 있는지 확인
+		boolean hasUnreadTopics = topicMemberRepository.existsByMemberAndIsReadFalse(member);
+		boolean hasUnreadKeywords = keywordMemberRepository.existsByMemberAndIsReadFalse(member);
+
+		// 둘 중 하나라도 읽지 않은 상태라면 false 반환
+		boolean isSubscribedTabRead = !(hasUnreadTopics || hasUnreadKeywords);
+
+		return new TabReadStatusResponse(isSubscribedTabRead);
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#68)

## 💻 작업 내용

> (작업내용작성)

- [x] 구독탭 읽음 상태 반환하는 api 추가
- [x] 안 읽은 TopicMember와 KeywordMember가 있는지 확인하는 JPA 메서드 추가
- [x] KeywordMember의 isRead 타입 boolean으로 변경

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
