### PR TITLE
feat: 공지사항 중복 검사 로직 추가 #70

### DIFF
--- a/src/main/java/com/example/ajouevent/dto/WebhookResponse.java
+++ b/src/main/java/com/example/ajouevent/dto/WebhookResponse.java
@@ -10,12 +10,14 @@ public class WebhookResponse {
 
 	private String result;
 	private String topic;
+	private String title;
 	private Long eventId;
 
 	@Builder
-	public WebhookResponse(String result, String topic, Long eventId) {
+	public WebhookResponse(String result, String topic, String title, Long eventId) {
 		this.result = result;
 		this.topic = topic;
+		this.title = title;
 		this.eventId = eventId;
 	}
 }

--- a/src/main/java/com/example/ajouevent/exception/CustomErrorCode.java
+++ b/src/main/java/com/example/ajouevent/exception/CustomErrorCode.java
@@ -36,7 +36,9 @@ public enum CustomErrorCode {
     KEYWORD_NOT_FOUND("키워드를 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()),
     PASSWORD_FAILED("비밀번호가 잘못되었습니다.", HttpStatus.BAD_REQUEST.value()),
     REISSUE_PASSWORD_FAILED("비밀번호를 재발급하던 도중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value()),
-    BANNER_NOT_FOUND("배너를 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value());
+    BANNER_NOT_FOUND("배너를 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()),
+    DUPLICATE_NOTICE("중복된 공지사항입니다.", HttpStatus.CONTINUE.value()),
+    INVALID_TYPE("존재하지 않은 공지사항 타입입니다.", HttpStatus.NOT_FOUND.value());
 
     private final String message;
     private final int statusCode;

--- a/src/main/java/com/example/ajouevent/facade/WebhookFacade.java
+++ b/src/main/java/com/example/ajouevent/facade/WebhookFacade.java
@@ -1,0 +1,67 @@
+package com.example.ajouevent.facade;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import com.example.ajouevent.dto.NoticeDto;
+import com.example.ajouevent.dto.WebhookResponse;
+import com.example.ajouevent.exception.CustomException;
+import com.example.ajouevent.logger.WebhookLogger;
+import com.example.ajouevent.service.EventService;
+import com.example.ajouevent.service.FCMService;
+import com.example.ajouevent.service.RedisService;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebhookFacade {
+
+	private final RedisService redisService;
+	private final EventService eventService;
+	private final FCMService fcmService;
+	private final WebhookLogger webhookLogger;
+
+	@Transactional
+	public ResponseEntity<WebhookResponse> processWebhook(String token, NoticeDto noticeDto) {
+		try {
+			// 토큰 검증
+			if (!redisService.isTokenValid("crawling-token", token)) {
+				return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+			}
+
+			// 공지사항 중복 여부 확인 - 공지사항 제목, 원래 공지사항 url 비교
+			boolean isDuplicate = eventService.isDuplicateNotice(noticeDto.getEnglishTopic(), noticeDto.getTitle(), noticeDto.getUrl());
+			if (isDuplicate) {
+				webhookLogger.log(String.format("Duplicate notice detected: %s, %s", noticeDto.getKoreanTopic(), noticeDto.getTitle()));
+				return ResponseEntity.status(HttpStatus.CONFLICT).body(
+					WebhookResponse.builder()
+						.result("Duplicate notice detected. Skipping processing.")
+						.topic(noticeDto.getEnglishTopic())
+						.title(noticeDto.getTitle())
+						.build()
+				);
+			}
+
+			// 크롤링한 공지사항을 DB에 저장
+			Long eventId = eventService.postNotice(noticeDto);
+
+			// 공지사항 Topic을 구독하고 있는 사용자에게 FCM 메시지 전송
+			return fcmService.sendNoticeNotification(noticeDto, eventId);
+
+		} catch (CustomException e) {
+			webhookLogger.log("Webhook 처리 중 오류 발생: " + e.getMessage());
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+				WebhookResponse.builder()
+					.result("Webhook 처리 실패: " + e.getMessage())
+					.topic(noticeDto.getEnglishTopic())
+					.title(noticeDto.getTitle())
+					.build()
+			);
+		}
+	}
+}

--- a/src/main/java/com/example/ajouevent/repository/EventRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/EventRepository.java
@@ -36,4 +36,6 @@ public interface EventRepository extends JpaRepository<ClubEvent, Long> {
 	void updateViews(@Param("viewCount") Long viewCount, @Param("eventId") Long eventId);
 
 	Slice<ClubEvent> findByTypeInAndTitleContaining(@Param("types") List<Type> types, @Param("keyword") String keyword, Pageable pageable);
+
+	List<ClubEvent> findTop10ByTypeOrderByCreatedAtDesc(Type type);
 }

--- a/src/main/java/com/example/ajouevent/service/EventService.java
+++ b/src/main/java/com/example/ajouevent/service/EventService.java
@@ -16,6 +16,7 @@ import com.example.ajouevent.domain.Keyword;
 import com.example.ajouevent.domain.KeywordMember;
 import com.example.ajouevent.dto.EventWithKeywordDto;
 import com.example.ajouevent.dto.MemberReadStatusDto;
+import com.example.ajouevent.logger.WebhookLogger;
 import com.example.ajouevent.repository.KeywordMemberRepository;
 import com.example.ajouevent.repository.KeywordRepository;
 import com.example.ajouevent.repository.TopicRepository;
@@ -92,6 +93,7 @@ public class EventService {
 	private final KeywordMemberRepository keywordMemberRepository;
 	private final JsonParsingUtil jsonParsingUtil;
 	private final CacheLogger cacheLogger;
+	private final WebhookLogger webhookLogger;
 	private final CookieService cookieService;
 	private final StringRedisTemplate stringRedisTemplate;
 	private final RedisService redisService;
@@ -1297,4 +1299,19 @@ public class EventService {
 		memberRepository.updateKeywordTabReadStatus(member, true);
 	}
 
+	@Transactional(readOnly = true)
+	public boolean isDuplicateNotice(String topic, String title, String url) {
+		Type type;
+		try {
+			type = Type.valueOf(topic.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			String errorMessage = String.format("잘못된 공지사항 Type 값: '%s' - 존재하지 않는 Enum 값입니다.", topic);
+			webhookLogger.log(errorMessage);
+			throw new CustomException(CustomErrorCode.INVALID_TYPE);
+		}
+
+		List<ClubEvent> recentEvents = eventRepository.findTop10ByTypeOrderByCreatedAtDesc(type);
+		return recentEvents.stream()
+			.anyMatch(event -> event.getTitle().equals(title) && event.getUrl().equals(url));
+	}
 }

--- a/src/main/java/com/example/ajouevent/service/FCMService.java
+++ b/src/main/java/com/example/ajouevent/service/FCMService.java
@@ -144,14 +144,24 @@ public class FCMService {
 			WebhookResponse webhookResponse = WebhookResponse.builder()
 				.result("Webhook 요청이 성공적으로 처리되었습니다.")
 				.topic(topicName)
+				.title(noticeDto.getTitle())
 				.eventId(eventId)
 				.build();
 			return ResponseEntity.ok().body(webhookResponse);
 		} catch (Exception e) {
-			log.error("공지사항 알림 전송 중 오류 발생", e);
+			String errorMessage = String.format(
+				"공지사항 알림 전송 중 오류 발생 - topic: %s, title: %s, error: %s",
+				noticeDto.getEnglishTopic(), noticeDto.getTitle(), e.getMessage()
+			);
+
+			webhookLogger.log(errorMessage); // webhookLogger로 로그 남김
+
 			return ResponseEntity.status(CustomErrorCode.TOPIC_NOTIFICATION_FAILED.getStatusCode()).body(
 				WebhookResponse.builder()
 					.result("Webhook 요청 처리 중 오류가 발생했습니다.")
+					.topic(noticeDto.getEnglishTopic())
+					.title(noticeDto.getTitle())
+					.eventId(eventId)
 					.build()
 			);
 		}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#70)

## 💻 작업 내용

- [x] 공지사항 중복 검사 로직 추가 - 공지사항 제목, 기존 공지사항 url
- [x] 퍼사드 패턴 적용

### 테스트 결과 or 스크린샷 (선택)

> 같은 Type의 공지사항인데 최근 10개 게시물에 같은 제목, 같은 url의 공지사항이 있으면 
<img width="709" alt="image" src="https://github.com/user-attachments/assets/22caacf6-b800-4239-bfaa-838a1d74c11a" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
