### PR TITLE
feat: fcm 토큰 유효성 검증 로직 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     runtimeOnly 'mysql:mysql-connector-java:8.0.32'
 
     // Firebase
-    implementation 'com.google.firebase:firebase-admin:9.1.1'
+    implementation 'com.google.firebase:firebase-admin:9.4.0'
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/com/example/ajouevent/domain/Token.java
+++ b/src/main/java/com/example/ajouevent/domain/Token.java
@@ -41,4 +41,11 @@ public class Token {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
+
+	@Column(nullable = false)
+	private boolean isDeleted = false;
+
+	public void markAsDeleted() {
+		this.isDeleted = true;
+	}
 }

--- a/src/main/java/com/example/ajouevent/logger/FcmTokenValidationLogger.java
+++ b/src/main/java/com/example/ajouevent/logger/FcmTokenValidationLogger.java
@@ -1,0 +1,22 @@
+package com.example.ajouevent.logger;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class FcmTokenValidationLogger {
+	private static final String LOG_FILE_PATH = "fcmTokenValidation_log.txt";
+
+	public void log(String message) {
+		try {
+			FileWriter writer = new FileWriter(LOG_FILE_PATH, true);
+			writer.write(LocalDateTime.now() + ": " + message + "\n");
+			writer.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/com/example/ajouevent/repository/TokenBulkRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/TokenBulkRepository.java
@@ -1,0 +1,46 @@
+package com.example.ajouevent.repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.example.ajouevent.domain.Token;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Repository
+public class TokenBulkRepository {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	public void updateTokens(List<Token> tokens) {
+		String sql = "UPDATE token SET is_deleted = ? WHERE id = ?";
+
+		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				Token token = tokens.get(i);
+				ps.setBoolean(1, token.isDeleted()); // is_deleted 값 설정
+				ps.setLong(2, token.getId());        // token의 ID 설정
+			}
+
+			@Override
+			public int getBatchSize() {
+				return tokens.size();
+			}
+		});
+
+		// 엔티티 분리
+		tokens.forEach(entityManager::detach);
+	}
+}

--- a/src/main/java/com/example/ajouevent/repository/TokenRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/TokenRepository.java
@@ -22,5 +22,8 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
 	@Modifying
 	@Query("delete from Token t where t.id in :tokenIds")
 	void deleteAllByTokenIds(@Param("tokenIds") List<Long> tokenIds);
+
+	// isDeleted가 false인 토큰 조회
+	List<Token> findByisDeletedFalse();
 }
 

--- a/src/main/java/com/example/ajouevent/scheduler/TokenValidationScheduler.java
+++ b/src/main/java/com/example/ajouevent/scheduler/TokenValidationScheduler.java
@@ -1,0 +1,115 @@
+package com.example.ajouevent.scheduler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.ajouevent.domain.Token;
+import com.example.ajouevent.logger.FcmTokenValidationLogger;
+import com.example.ajouevent.repository.KeywordTokenRepository;
+import com.example.ajouevent.repository.TokenBulkRepository;
+import com.example.ajouevent.repository.TokenRepository;
+import com.example.ajouevent.repository.TopicTokenRepository;
+import com.example.ajouevent.service.FCMService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class TokenValidationScheduler {
+
+	private static final int BATCH_SIZE = 400; // 배치 크기 설정
+	private final TokenRepository tokenRepository;
+	private final FCMService fcmService;
+	private final TopicTokenRepository topicTokenRepository;
+	private final KeywordTokenRepository keywordTokenRepository;
+	private final FcmTokenValidationLogger fcmTokenValidationLogger;
+	private final TokenBulkRepository tokenBulkRepository;
+
+	@Scheduled(cron = "0 0 5 ? * SUN") // 매주 일요일 새벽 5시
+	@Transactional
+	public void validateAndRemoveInvalidTokens() {
+		log.info("FCM 토큰 유효성 검사 및 삭제를 시작합니다.");
+
+		fcmTokenValidationLogger.log("[START] FCM 토큰 유효성 검사 및 삭제 프로세스 시작");
+
+		// 삭제 표시 되지 않은 토큰만 가져오기
+		List<Token> tokens = tokenRepository.findByisDeletedFalse();
+		fcmTokenValidationLogger.log("현재 저장된 활성 토큰 개수: " + tokens.size());
+
+		// 토큰 값 추출
+		List<String> tokenValues = tokens.stream()
+			.map(Token::getTokenValue)
+			.collect(Collectors.toList());
+
+		// 배치 단위로 토큰 검증
+		List<String> invalidTokens = batchValidateTokens(tokenValues);
+
+		if (invalidTokens.isEmpty()) {
+			fcmTokenValidationLogger.log("모든 토큰이 유효합니다. 삭제할 토큰 없음.");
+			fcmTokenValidationLogger.log("[END] FCM 토큰 유효성 검사 종료");
+			return;
+		}
+
+		fcmTokenValidationLogger.log("유효하지 않은 토큰 개수: " + invalidTokens.size());
+
+		// 유효하지 않은 토큰과 관련된 Token 엔터티 찾기
+		List<Token> invalidTokenEntities = tokens.stream()
+			.filter(token -> invalidTokens.contains(token.getTokenValue()))
+			.collect(Collectors.toList());
+
+		// 무효 토큰 isDeleted 상태 업데이트
+		markTokensAsDeleted(invalidTokenEntities);
+
+		// // 무효 토큰 삭제
+		// deleteInvalidTokensFromDB(invalidTokenEntities);
+		fcmTokenValidationLogger.log("[END] FCM 토큰 유효성 검사 및 삭제 완료");
+	}
+
+	private List<String> batchValidateTokens(List<String> tokenValues) {
+		List<String> invalidTokens = new ArrayList<>();
+		int totalTokens = tokenValues.size();
+		int batchCount = (int) Math.ceil((double) totalTokens / BATCH_SIZE);
+
+		fcmTokenValidationLogger.log(" 총 " + totalTokens + "개의 토큰을 " + BATCH_SIZE + "개씩 배치 처리 (총 " + batchCount + "개 배치)");
+
+		for (int i = 0; i < batchCount; i++) {
+			int fromIndex = i * BATCH_SIZE;
+			int toIndex = Math.min(fromIndex + BATCH_SIZE, totalTokens);
+			List<String> batch = tokenValues.subList(fromIndex, toIndex);
+
+			List<String> batchInvalidTokens = fcmService.validateTokens(batch);
+			invalidTokens.addAll(batchInvalidTokens);
+
+			fcmTokenValidationLogger.log(" 배치 " + (i + 1) + " 완료 | " + fromIndex + " ~ " + (toIndex - 1) + "번 토큰 검증 | 무효 토큰 수: " + batchInvalidTokens.size());
+		}
+
+		return invalidTokens;
+	}
+
+	private void markTokensAsDeleted(List<Token> invalidTokens) {
+		invalidTokens.forEach(Token::markAsDeleted);
+		tokenBulkRepository.updateTokens(invalidTokens);
+		fcmTokenValidationLogger.log(invalidTokens.size() + "개의 유효하지 않은 토큰을 isDeleted=true로 업데이트 완료");
+	}
+
+	private void deleteInvalidTokensFromDB(List<Token> invalidTokens) {
+		List<Long> invalidTokenIds = invalidTokens.stream()
+			.map(Token::getId)
+			.collect(Collectors.toList());
+
+		fcmTokenValidationLogger.log("유효하지 않은 토큰 삭제 진행 중... (총 " + invalidTokenIds.size() + "개)");
+
+		topicTokenRepository.deleteAllByTokenIds(invalidTokenIds);
+		keywordTokenRepository.deleteAllByTokenIds(invalidTokenIds);
+		tokenRepository.deleteAllByTokenIds(invalidTokenIds);
+
+		fcmTokenValidationLogger.log(invalidTokenIds.size() + "개의 유효하지 않은 토큰 및 관련 데이터를 삭제 완료");
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#66 )

## 💻 작업 내용

> 주기적으로 토큰에 테스트 메시지를 날려 토큰의 유효성을 검증하는 로직 추가

- [x] fcm SDK 9.4.0 업그레이드 (sendEachForMulticast 사용)
- [x] 테스트용 fcm 푸시 알림 메서드 작성
- [x] 주기적으로 토큰에 대해 푸시 알림을 보내는 스케줄러 작성
- [x] Token 엔티티에 soft deleted 필드 추가
- [x] fcm 토큰 유효성 검사 로그 생성
- [x] Token Bulk 처리 레포지토리 생성

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
