### PR TITLE
feat: 학과 이름 변경, 신설학과 토픽 추가 #77

### DIFF
--- a/src/main/java/com/example/ajouevent/domain/Type.java
+++ b/src/main/java/com/example/ajouevent/domain/Type.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Type {
 
-    AIMOBILITYENGINEERING("AIMobilityEngineering", "AI모빌리티공학과"),
+    AIMOBILITYENGINEERING("AIMobilityEngineering", "미래모빌리티공학과"),
     AJOUNORMAL("AjouNormal", "아주대학교-일반"),
     AJOUSCHOLARSHIP("AjouScholarship", "아주대학교-장학"),
     APPLIEDARTIFICIALINTELLIGENCE("AppliedArtificialIntelligence", "인공지능융합학과"),
@@ -60,7 +60,11 @@ public enum Type {
     SPORTSLEISURESTUDIES("SportsLeisureStudies", "스포츠레저학과"),
     TRANSPORTATIONSYSTEMSENGINEERING("TransportationSystemsEngineering", "교통시스템공학과"),
     DORMITORY("Dormitory", "기숙사"),
-    TEST("Test", "테스트");
+    TEST("Test", "테스트"),
+    APPLIEDCHEMISTRY("AppliedChemistry", "응용화학과"),
+    ECONOMICPOLITICALANDSOCIALSTUDIES("EconomicPoliticalAndSocialStudies", "경제정치사회융합학부"),
+    FRONTIERSCIENCES("FrontierSciences", "프런티어과학학부"),
+    LIBERALSTUDIES("LiberalStudies", "자유전공학부");
 
 
     private final String englishTopic;


### PR DESCRIPTION
- AI모빌리티공학과 -> 미래모빌리티공학과
- 자유전공학부, 프런티어과학학부, 응용화학과, 경제정치사회융합학부 - Topic, Type에 추가

## #️⃣ 연관 이슈

> (#77)

## 💻 작업 내용

> 학과 이름 변경, 신설학과 토픽. 추가

- [x] AI모빌리티공학과 -> 미래모빌리티공학과

- [x] 자유전공학부, 프런티어과학학부, 응용화학과, 경제정치사회융합학부 - Topic, Type에 추가

### 테스트 결과 or 스크린샷 (선택)

> 
<img width="372" alt="image" src="https://github.com/user-attachments/assets/f26ada94-7cbb-46dc-92e6-2846c941d019" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
