### PR TITLE
refactor: 사용자 Topic, Keyword 탭 읽음 상태, Topic, Keyword 읽음 상태 관리 리팩토링 (#79)

### DIFF
--- a/src/main/java/com/example/ajouevent/repository/KeywordMemberBulkRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/KeywordMemberBulkRepository.java
@@ -1,0 +1,48 @@
+package com.example.ajouevent.repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.example.ajouevent.domain.KeywordMember;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Repository
+public class KeywordMemberBulkRepository {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	public void updateKeywordMembers(List<KeywordMember> keywordMembers) {
+		String sql = "UPDATE keyword_member SET is_read = ?, last_read_at = ? WHERE id = ?";
+
+		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				KeywordMember keywordMember = keywordMembers.get(i);
+				ps.setBoolean(1, keywordMember.isRead());
+				ps.setTimestamp(2, Timestamp.valueOf(keywordMember.getLastReadAt()));
+				ps.setLong(3, keywordMember.getId());
+			}
+
+			@Override
+			public int getBatchSize() {
+				return keywordMembers.size();
+			}
+		});
+
+		// 엔티티 분리
+		keywordMembers.forEach(entityManager::detach);
+	}
+}

--- a/src/main/java/com/example/ajouevent/repository/TopicMemberBulkRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/TopicMemberBulkRepository.java
@@ -1,0 +1,48 @@
+package com.example.ajouevent.repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.example.ajouevent.domain.TopicMember;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Repository
+public class TopicMemberBulkRepository {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	public void updateTopicMembers(List<TopicMember> topicMembers) {
+		String sql = "UPDATE topic_member SET is_read = ?, last_read_at = ? WHERE id = ?";
+
+		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				TopicMember topicMember = topicMembers.get(i);
+				ps.setBoolean(1, topicMember.isRead());
+				ps.setTimestamp(2, Timestamp.valueOf(topicMember.getLastReadAt()));
+				ps.setLong(3, topicMember.getId());
+			}
+
+			@Override
+			public int getBatchSize() {
+				return topicMembers.size();
+			}
+		});
+
+		// 엔티티 분리
+		topicMembers.forEach(entityManager::detach);
+	}
+}

--- a/src/main/java/com/example/ajouevent/service/EventService.java
+++ b/src/main/java/com/example/ajouevent/service/EventService.java
@@ -17,8 +17,10 @@ import com.example.ajouevent.domain.KeywordMember;
 import com.example.ajouevent.dto.EventWithKeywordDto;
 import com.example.ajouevent.dto.MemberReadStatusDto;
 import com.example.ajouevent.logger.WebhookLogger;
+import com.example.ajouevent.repository.KeywordMemberBulkRepository;
 import com.example.ajouevent.repository.KeywordMemberRepository;
 import com.example.ajouevent.repository.KeywordRepository;
+import com.example.ajouevent.repository.TopicMemberBulkRepository;
 import com.example.ajouevent.repository.TopicRepository;
 import com.example.ajouevent.util.SecurityUtil;
 import com.example.ajouevent.util.JsonParsingUtil;
@@ -102,6 +104,8 @@ public class EventService {
 	final Long DEFAULT_LIKES_COUNT = 0L;
 	final Long DEFAULT_VIEW_COUNT = 0L;
 	private final TopicRepository topicRepository;
+	private final TopicMemberBulkRepository topicMemberBulkRepository;
+	private final KeywordMemberBulkRepository keywordMemberBulkRepository;
 
 	// 크롤링한 공지사항 DB에 저장
 	@Transactional
@@ -170,11 +174,9 @@ public class EventService {
 		for (TopicMember topicMember : topicMembers) {
 			topicMember.setRead(false);  // 읽음 상태를 읽지 않음으로 설정
 			topicMember.setLastReadAt(LocalDateTime.now());
-			topicMemberRepository.save(topicMember);  // 업데이트된 읽음 상태 저장
-
-			// Member의 구독탭 상태를 false로 업데이트
-			memberRepository.updateTopicTabReadStatus(topicMember.getMember(), false);
 		}
+
+		topicMemberBulkRepository.updateTopicMembers(topicMembers);
 
 		List<Keyword> keywords = keywordRepository.findByTopic(topic);
 
@@ -191,11 +193,8 @@ public class EventService {
 				for (KeywordMember keywordMember : keywordMembers) {
 					keywordMember.setRead(false);  // 읽음 상태를 읽지 않음으로 설정
 					keywordMember.setLastReadAt(LocalDateTime.now());
-					keywordMemberRepository.save(keywordMember);
-
-					// Member의 키워드탭 상태를 false로 업데이트
-					memberRepository.updateKeywordTabReadStatus(keywordMember.getMember(), false);
 				}
+				keywordMemberBulkRepository.updateKeywordMembers(keywordMembers);
 			}
 		}
 


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#79)

## 💻 작업 내용

> 기존 member 엔티티에 topic, keyword 탭 읽음 상태로 관리하던 부분 삭제 + 사용자마다 Topic, Keyword 읽음 상태 Bulk 처리 

- [x] Member 엔티티 구독탭 상태 업데이트 부분 삭제(데드락 문제)
- [x] 사용자의 Topic, Keyword 읽음 상태 하나씩 처리하던 부분 -> Bulk로 변경  

### 테스트 결과 or 스크린샷 (선택)

<img width="1637" alt="Image" src="https://github.com/user-attachments/assets/17d47aaf-1a95-479d-b17b-09293c811f27" />

<img width="1650" alt="Image" src="https://github.com/user-attachments/assets/3b044645-3dfe-4020-8ef9-87a79c20525f" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
