### PR TITLE
refactor: FCM Topic -> Token 방식으로 알림 방식 전환, 알림 목록 추가 (#67)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,10 @@ bin/
 ### IntelliJ IDEA ###
 application.properties
 application.yml
+application-prod.yml
 application-dev.yml
 /src/main/resources/*.yml
+/src/test/resources/*.yml
 
 .idea
 *.iws

--- a/src/main/java/com/example/ajouevent/controller/PushClusterController.java
+++ b/src/main/java/com/example/ajouevent/controller/PushClusterController.java
@@ -1,0 +1,51 @@
+package com.example.ajouevent.controller;
+
+import java.util.List;
+
+import com.example.ajouevent.dto.PushClusterStatsResponse;
+import com.example.ajouevent.dto.ResponseDto;
+import com.example.ajouevent.service.PushClusterService;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/push-cluster")
+public class PushClusterController {
+
+	private final PushClusterService pushClusterService;
+
+	@GetMapping("")
+	public List<PushClusterStatsResponse> getPushClusterStats() {
+		return pushClusterService.calculateAllPushClusterStats();
+	}
+
+	@PostMapping("/received")
+	public ResponseEntity<ResponseDto> incrementReceived(@RequestBody Long pushClusterId) {
+		pushClusterService.incrementReceived(pushClusterId);
+		return ResponseEntity.ok().body(ResponseDto.builder()
+			.successStatus(HttpStatus.OK)
+			.successContent("Push received count incremented.")
+			.Data(pushClusterId)
+			.build()
+		);
+	}
+
+	@PostMapping("/clicked")
+	public ResponseEntity<ResponseDto> incrementClicked(@RequestBody Long pushClusterId) {
+		pushClusterService.incrementClicked(pushClusterId);
+		return ResponseEntity.ok().body(ResponseDto.builder()
+			.successStatus(HttpStatus.OK)
+			.successContent("Push clicked count incremented.")
+			.Data(pushClusterId)
+			.build()
+		);
+	}
+}

--- a/src/main/java/com/example/ajouevent/controller/PushNotificationController.java
+++ b/src/main/java/com/example/ajouevent/controller/PushNotificationController.java
@@ -1,0 +1,65 @@
+package com.example.ajouevent.controller;
+
+import static org.springframework.data.domain.Sort.Direction.*;
+
+import java.security.Principal;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.ajouevent.dto.KeywordNotificationResponse;
+import com.example.ajouevent.dto.NotificationClickRequest;
+import com.example.ajouevent.dto.ResponseDto;
+import com.example.ajouevent.dto.SliceResponse;
+import com.example.ajouevent.dto.TopicNotificationResponse;
+import com.example.ajouevent.dto.UnreadNotificationCountResponse;
+import com.example.ajouevent.service.PushNotificationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notification")
+public class PushNotificationController {
+
+	private final PushNotificationService pushNotificationService;
+
+	// Topic 알림 조회 API
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping("/topic")
+	public SliceResponse<TopicNotificationResponse> getTopicNotifications(@PageableDefault(sort = "notifiedAt", direction = DESC) Pageable pageable) {
+		return pushNotificationService.getTopicNotificationsForMember(pageable);
+	}
+
+	// Keyword 알림 조회 API
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping("/keyword")
+	public SliceResponse<KeywordNotificationResponse> getKeywordNotifications(@PageableDefault(sort = "notifiedAt", direction = DESC) Pageable pageable) {
+		return pushNotificationService.getKeywordNotificationsForMember(pageable);
+	}
+
+	@PreAuthorize("isAuthenticated()")
+	@PostMapping("/click")
+	public ResponseEntity<ResponseDto> markNotificationAsRead(@RequestBody NotificationClickRequest notificationClickRequest, Principal principal) {
+		pushNotificationService.markNotificationAsRead(notificationClickRequest);
+		return ResponseEntity.ok().body(ResponseDto.builder()
+			.successStatus(HttpStatus.OK)
+			.successContent("푸시 알림을 클릭합니다.")
+			.Data(notificationClickRequest.getPushNotificationId())
+			.build()
+		);
+	}
+
+	@GetMapping("/unread-count")
+	public UnreadNotificationCountResponse getUnreadNotificationCount(Principal principal) {
+		return pushNotificationService.getUnreadNotificationCount(principal);
+	}
+}

--- a/src/main/java/com/example/ajouevent/domain/JobStatus.java
+++ b/src/main/java/com/example/ajouevent/domain/JobStatus.java
@@ -1,0 +1,10 @@
+package com.example.ajouevent.domain;
+
+public enum JobStatus {
+	PENDING,     // 작업 대기 상태 (초기값)
+	IN_PROGRESS, // 작업 진행 중
+	SUCCESS,     // 작업 완료 (성공)
+	PARTIAL_FAIL, // 작업 완료 (부분 실패)
+	FAIL,         // 작업 실패
+	NONE		// 보낼 대상이 없음 (푸시 알림 대상 없음)
+}

--- a/src/main/java/com/example/ajouevent/domain/NotificationType.java
+++ b/src/main/java/com/example/ajouevent/domain/NotificationType.java
@@ -1,0 +1,6 @@
+package com.example.ajouevent.domain;
+
+public enum NotificationType {
+	TOPIC,
+	KEYWORD
+}

--- a/src/main/java/com/example/ajouevent/domain/PushCluster.java
+++ b/src/main/java/com/example/ajouevent/domain/PushCluster.java
@@ -1,0 +1,102 @@
+package com.example.ajouevent.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PushCluster {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "club_event_id", nullable = true) // 연관된 이벤트
+	private ClubEvent clubEvent;
+
+	@Column(nullable = false)
+	private String title; // 푸시 알림 제목
+
+	@Column(nullable = false)
+	private String body; // 푸시 알림 내용
+
+	@Column(nullable = false)
+	private String imageUrl; // 알림 이미지 URL
+
+	@Column(nullable = false)
+	private String clickUrl; // 알림 클릭 시 이동 URL
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private JobStatus jobStatus = JobStatus.PENDING; // 작업 상태 (초기값: PENDING), SUCCESS, FAIL
+
+	@Column(nullable = false)
+	private int totalCount = 0; // 총 발송 토큰 수
+
+	@Column(nullable = false)
+	private LocalDateTime registeredAt; // 푸시 클러스터 등록 시간
+
+	@Column(nullable = false)
+	private int successCount = 0; // 성공한 토큰 수
+
+	@Column(nullable = false)
+	private int failCount = 0; // 실패한 토큰 수
+
+	@Column(nullable = false)
+	private int receivedCount = 0; // 수신 수
+
+	@Column(nullable = false)
+	private int clickedCount = 0; // 클릭 수
+
+	@Column(nullable = true)
+	private LocalDateTime startAt = LocalDateTime.now(); // 작업 시작 시간
+
+	@Column(nullable = true)
+	private LocalDateTime endAt = LocalDateTime.now(); // 작업 종료 시간
+
+	@OneToMany(mappedBy = "pushCluster", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<PushClusterToken> tokens; // 발송 작업에 포함된 토큰들
+
+	// 작업 시작 기록
+	public void markAsInProgress() {
+		this.startAt = LocalDateTime.now();
+		this.jobStatus = JobStatus.IN_PROGRESS;
+	}
+
+	// 성공, 실패 카운트와 작업 상태를 변경
+	public void updateCountsAndStatus(int successCount, int failCount) {
+		this.successCount = successCount;
+		this.failCount = failCount;
+		if (successCount == 0 && failCount == 0) {
+			this.jobStatus = JobStatus.NONE; // 보낼 대상이 없었음
+		} else if (failCount > 0) {
+			this.jobStatus = JobStatus.PARTIAL_FAIL; // 일부 실패
+		} else {
+			this.jobStatus = JobStatus.SUCCESS; // 전체 성공
+		}
+
+		this.endAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/example/ajouevent/domain/PushCluster.java
+++ b/src/main/java/com/example/ajouevent/domain/PushCluster.java
@@ -87,8 +87,8 @@ public class PushCluster {
 
 	// 성공, 실패 카운트와 작업 상태를 변경
 	public void updateCountsAndStatus(int successCount, int failCount) {
-		this.successCount = successCount;
-		this.failCount = failCount;
+		this.successCount += successCount; // 배치 처리라서 +로 (누적 처리)
+		this.failCount += failCount; // 배치 처리라서 +로 (누적 처리)
 		if (successCount == 0 && failCount == 0) {
 			this.jobStatus = JobStatus.NONE; // 보낼 대상이 없었음
 		} else if (failCount > 0) {

--- a/src/main/java/com/example/ajouevent/domain/PushClusterToken.java
+++ b/src/main/java/com/example/ajouevent/domain/PushClusterToken.java
@@ -47,6 +47,11 @@ public class PushClusterToken {
 	@Column(nullable = true)
 	private LocalDateTime processedTime; // 발송 처리 시간
 
+	public void markAsSending() {
+		this.jobStatus = JobStatus.IN_PROGRESS;
+		this.processedTime = LocalDateTime.now();
+	}
+
 	public void markAsSuccess() {
 		this.jobStatus = JobStatus.SUCCESS;
 		this.processedTime = LocalDateTime.now();

--- a/src/main/java/com/example/ajouevent/domain/PushClusterToken.java
+++ b/src/main/java/com/example/ajouevent/domain/PushClusterToken.java
@@ -1,0 +1,59 @@
+package com.example.ajouevent.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PushClusterToken {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "push_cluster_id", nullable = false)
+	private PushCluster pushCluster;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "token_id", nullable = false)
+	private Token token;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private JobStatus jobStatus = JobStatus.PENDING; // 토큰 상태 (초기값: PENDING), SUCCESS, FAIL
+
+	@Column(nullable = false)
+	private LocalDateTime requestTime; // 발송 요청 시간
+
+	@Column(nullable = true)
+	private LocalDateTime processedTime; // 발송 처리 시간
+
+	public void markAsSuccess() {
+		this.jobStatus = JobStatus.SUCCESS;
+		this.processedTime = LocalDateTime.now();
+	}
+
+	public void markAsFail() {
+		this.jobStatus = JobStatus.FAIL;
+		this.processedTime = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/example/ajouevent/domain/PushNotification.java
+++ b/src/main/java/com/example/ajouevent/domain/PushNotification.java
@@ -1,0 +1,77 @@
+package com.example.ajouevent.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PushNotification {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "push_cluster_id", nullable = false)
+	private PushCluster pushCluster; // 발송 작업과 연결
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "topic_id", nullable = true)
+	private Topic topic;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "keyword_id", nullable = true)
+	private Keyword keyword;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private NotificationType notificationType; // 알림 유형 (TOPIC, KEYWORD)
+
+	@Column(nullable = false)
+	private String title; // 알림 제목
+
+	@Column(nullable = false)
+	private String body; // 알림 내용
+
+	@Column(nullable = false)
+	private String imageUrl; // 알림 이미지 URL
+
+	@Column(nullable = false)
+	private String clickUrl; // 알림 클릭 시 이동 URL
+
+	@Column(nullable = false)
+	private boolean isRead = false; // 알림 클릭 여부
+
+	@Column(nullable = true)
+	private LocalDateTime clickedAt; // 알림 클릭 시간
+
+	@Column(nullable = true)
+	private LocalDateTime notifiedAt; // 알림 전달 시간
+
+	public void markAsRead() {
+		this.isRead = true;
+		this.clickedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/example/ajouevent/dto/KeywordNotificationResponse.java
+++ b/src/main/java/com/example/ajouevent/dto/KeywordNotificationResponse.java
@@ -1,0 +1,38 @@
+package com.example.ajouevent.dto;
+
+import java.time.LocalDateTime;
+
+import com.example.ajouevent.domain.PushNotification;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class KeywordNotificationResponse {
+	private Long id; // 푸시 알림 ID
+	private String title; // 푸시 알림 제목
+	private String imageUrl; // 알림 이미지 URL
+	private String clickUrl; // 클릭 시 URL
+	private boolean isRead; // 읽음 여부
+	private LocalDateTime notifiedAt; // 알림 시간
+	private String topicName; // Topic의 이름
+	private String keywordName; // Keyword의 이름
+
+	public static KeywordNotificationResponse toDto(PushNotification pushNotification) {
+		return KeywordNotificationResponse.builder()
+			.id(pushNotification.getId())
+			.title(pushNotification.getBody())
+			.imageUrl(pushNotification.getImageUrl())
+			.clickUrl(pushNotification.getClickUrl())
+			.isRead(pushNotification.isRead())
+			.notifiedAt(pushNotification.getNotifiedAt())
+			.topicName(pushNotification.getTopic().getKoreanTopic())
+			.keywordName(pushNotification.getKeyword().getKoreanKeyword()) // Keyword 이름
+			.build();
+	}
+}

--- a/src/main/java/com/example/ajouevent/dto/NotificationClickRequest.java
+++ b/src/main/java/com/example/ajouevent/dto/NotificationClickRequest.java
@@ -1,0 +1,20 @@
+package com.example.ajouevent.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+public class NotificationClickRequest {
+
+	private Long pushNotificationId;
+
+	@JsonCreator
+	public NotificationClickRequest(Long pushNotificationId) {
+		this.pushNotificationId = pushNotificationId;
+	}
+}

--- a/src/main/java/com/example/ajouevent/dto/PushClusterStatsResponse.java
+++ b/src/main/java/com/example/ajouevent/dto/PushClusterStatsResponse.java
@@ -1,0 +1,30 @@
+package com.example.ajouevent.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PushClusterStatsResponse {
+	private Long pushClusterId; // PushCluster ID
+	private String title; // 푸시 제목
+	private int totalTokens; // 총 발송 토큰 수
+	private int successfulTokens; // 성공한 토큰 수
+	private int failedTokens; // 실패한 토큰 수
+	private int totalNotifications; // 총 알림 수
+	private int clickedNotifications; // 클릭된 알림 수
+	private double deliveryRate; // 수신률 (%)
+	private double clickRate; // 클릭률 (%)
+	private String url; // 푸시 랜딩 URL
+	private String jobStatus; // 작업 상태
+
+	private LocalDateTime registerAt; // 발송 등록 시간
+	private LocalDateTime startAt; // 발송 시작 시간
+	private LocalDateTime endAt; // 발송 완료 시간
+}

--- a/src/main/java/com/example/ajouevent/dto/TopicNotificationResponse.java
+++ b/src/main/java/com/example/ajouevent/dto/TopicNotificationResponse.java
@@ -1,0 +1,36 @@
+package com.example.ajouevent.dto;
+
+import java.time.LocalDateTime;
+
+import com.example.ajouevent.domain.PushNotification;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TopicNotificationResponse {
+	private Long id; // 푸시 알림 ID
+	private String title; // 푸시 알림 제목
+	private String imageUrl; // 알림 이미지 URL
+	private String clickUrl; // 클릭 시 URL
+	private boolean isRead; // 읽음 여부
+	private LocalDateTime notifiedAt; // 알림 시간
+	private String topicName; // Topic의 이름
+
+	public static TopicNotificationResponse toDto(PushNotification pushNotification) {
+		return TopicNotificationResponse.builder()
+			.id(pushNotification.getId())
+			.title(pushNotification.getBody())
+			.imageUrl(pushNotification.getImageUrl())
+			.clickUrl(pushNotification.getClickUrl())
+			.isRead(pushNotification.isRead())
+			.notifiedAt(pushNotification.getNotifiedAt())
+			.topicName(pushNotification.getTopic().getKoreanTopic()) // Topic 이름
+			.build();
+	}
+}

--- a/src/main/java/com/example/ajouevent/dto/UnreadNotificationCountDto.java
+++ b/src/main/java/com/example/ajouevent/dto/UnreadNotificationCountDto.java
@@ -1,0 +1,20 @@
+package com.example.ajouevent.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UnreadNotificationCountDto {
+	private Long memberId;
+	private Long unreadNotificationCount;
+
+	public UnreadNotificationCountDto(Number memberId, Number unreadNotificationCount) {
+		this.memberId = memberId.longValue();
+		this.unreadNotificationCount = unreadNotificationCount.longValue();
+	}
+}

--- a/src/main/java/com/example/ajouevent/dto/UnreadNotificationCountResponse.java
+++ b/src/main/java/com/example/ajouevent/dto/UnreadNotificationCountResponse.java
@@ -1,0 +1,19 @@
+package com.example.ajouevent.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+public class UnreadNotificationCountResponse {
+	private int unreadNotificationCount;
+
+	@JsonCreator
+	public UnreadNotificationCountResponse(int unreadNotificationCountCount) {
+		this.unreadNotificationCount = unreadNotificationCountCount;
+	}
+}

--- a/src/main/java/com/example/ajouevent/exception/CustomErrorCode.java
+++ b/src/main/java/com/example/ajouevent/exception/CustomErrorCode.java
@@ -38,7 +38,9 @@ public enum CustomErrorCode {
     REISSUE_PASSWORD_FAILED("비밀번호를 재발급하던 도중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value()),
     BANNER_NOT_FOUND("배너를 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()),
     DUPLICATE_NOTICE("중복된 공지사항입니다.", HttpStatus.CONTINUE.value()),
-    INVALID_TYPE("존재하지 않은 공지사항 타입입니다.", HttpStatus.NOT_FOUND.value());
+    INVALID_TYPE("존재하지 않은 공지사항 타입입니다.", HttpStatus.NOT_FOUND.value()),
+    PUSH_CLUSTER_NOT_FOUND("푸시 작업을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()),
+    PUSH_NOTIFICATION_NOT_FOUND("푸시 알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value());
 
     private final String message;
     private final int statusCode;

--- a/src/main/java/com/example/ajouevent/logger/PushClusterLogger.java
+++ b/src/main/java/com/example/ajouevent/logger/PushClusterLogger.java
@@ -1,0 +1,23 @@
+package com.example.ajouevent.logger;
+
+import org.springframework.stereotype.Component;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+public class PushClusterLogger {
+
+	private static final String LOG_FILE_PATH = "push_cluster_log.txt";
+
+	public void log(String message) {
+		try {
+			FileWriter writer = new FileWriter(LOG_FILE_PATH, true);
+			writer.write(LocalDateTime.now() + ": " + message + "\n");
+			writer.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/com/example/ajouevent/repository/KeywordTokenRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/KeywordTokenRepository.java
@@ -27,4 +27,6 @@ public interface KeywordTokenRepository extends JpaRepository<KeywordToken, Long
 	@Query("SELECT kt FROM KeywordToken kt JOIN FETCH kt.keyword WHERE kt.token IN :tokens")
 	List<KeywordToken> findKeywordTokensWithKeyword(@Param("tokens") List<Token> tokens);
 
+	@Query("SELECT kt FROM KeywordToken kt JOIN FETCH kt.token t WHERE kt.keyword = :keyword AND t.isDeleted = false")
+	List<KeywordToken> findKeywordTokensWithTokenByKeyword(@Param("keyword") Keyword keyword);
 }

--- a/src/main/java/com/example/ajouevent/repository/MemberRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/MemberRepository.java
@@ -23,6 +23,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	@Query("SELECT m FROM Member m LEFT JOIN FETCH m.tokens WHERE m.email = :email")
 	Optional<Member> findByEmailWithTokens(@Param("email") String email);
 
+	@Query("SELECT m FROM Member m LEFT JOIN FETCH m.tokens t WHERE m.email = :email AND t.isDeleted = false")
+	Optional<Member> findByEmailWithValidTokens(@Param("email") String email);
+
 	boolean existsByEmailAndName(@Param("email") String email, @Param("name") String name);
 
 	boolean existsByEmail(String email);

--- a/src/main/java/com/example/ajouevent/repository/PushClusterBulkRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/PushClusterBulkRepository.java
@@ -1,0 +1,49 @@
+package com.example.ajouevent.repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.example.ajouevent.domain.PushCluster;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Repository
+public class PushClusterBulkRepository {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	public void updateAll(List<PushCluster> pushClusters) {
+		String sql = "UPDATE push_cluster SET received_count = ?, clicked_count = ? WHERE id = ?";
+
+
+		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				PushCluster pushCluster = pushClusters.get(i);
+
+				ps.setInt(1, pushCluster.getReceivedCount()); // received_count
+				ps.setInt(2, pushCluster.getClickedCount()); // clicked_count
+				ps.setLong(3, pushCluster.getId()); // id
+			}
+
+			@Override
+			public int getBatchSize() {
+				return pushClusters.size();
+			}
+		});
+
+		// 엔티티 분리
+		pushClusters.forEach(entityManager::detach);
+	}
+}

--- a/src/main/java/com/example/ajouevent/repository/PushClusterRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/PushClusterRepository.java
@@ -1,0 +1,11 @@
+package com.example.ajouevent.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.ajouevent.domain.PushCluster;
+
+@Repository
+public interface PushClusterRepository extends JpaRepository<PushCluster, Long> {
+
+}

--- a/src/main/java/com/example/ajouevent/repository/PushClusterTokenBulkRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/PushClusterTokenBulkRepository.java
@@ -1,0 +1,79 @@
+package com.example.ajouevent.repository;
+
+import com.example.ajouevent.domain.PushClusterToken;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Repository
+public class PushClusterTokenBulkRepository {
+
+	private static final Logger log = LoggerFactory.getLogger(PushClusterTokenBulkRepository.class);
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	public void saveAll(List<PushClusterToken> clusterTokens) {
+		log.info("PushClusterTokenBulkRepository saveAll");
+
+		String sql = "INSERT INTO push_cluster_token (push_cluster_id, token_id, job_status, request_time, processed_time) VALUES (?, ?, ?, ?, ?)";
+
+		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				PushClusterToken clusterToken = clusterTokens.get(i);
+				ps.setLong(1, clusterToken.getPushCluster().getId());
+				ps.setLong(2, clusterToken.getToken().getId());
+				ps.setString(3, clusterToken.getJobStatus().name());
+				ps.setTimestamp(4, java.sql.Timestamp.valueOf(clusterToken.getRequestTime()));
+				ps.setTimestamp(5, clusterToken.getProcessedTime() != null ?
+					java.sql.Timestamp.valueOf(clusterToken.getProcessedTime()) : null); // processedTime 추가
+			}
+
+			@Override
+			public int getBatchSize() {
+				return clusterTokens.size();
+			}
+		});
+	}
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	public void updateAll(List<PushClusterToken> clusterTokens) {
+		String sql = "UPDATE push_cluster_token " +
+			"SET job_status = ?, processed_time = ?, push_cluster_id = ?, request_time = ?, token_id = ? WHERE id = ?";
+
+		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				PushClusterToken token = clusterTokens.get(i);
+				ps.setString(1, token.getJobStatus().name());
+				ps.setTimestamp(2, java.sql.Timestamp.valueOf(token.getProcessedTime()));
+				ps.setLong(3, token.getPushCluster().getId()); // push_cluster_id
+				ps.setTimestamp(4, java.sql.Timestamp.valueOf(token.getRequestTime())); // request_time
+				ps.setLong(5, token.getToken().getId()); // token_id
+				ps.setLong(6, token.getId()); // id
+			}
+
+			@Override
+			public int getBatchSize() {
+				return clusterTokens.size();
+			}
+		});
+
+		// 엔티티 분리
+		clusterTokens.forEach(entityManager::detach);
+	}
+}

--- a/src/main/java/com/example/ajouevent/repository/PushClusterTokenRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/PushClusterTokenRepository.java
@@ -15,4 +15,7 @@ public interface PushClusterTokenRepository extends JpaRepository<PushClusterTok
 
 	@Query("SELECT pct FROM PushClusterToken pct JOIN FETCH pct.token t WHERE pct.pushCluster = :pushCluster")
 	List<PushClusterToken> findAllByPushClusterWithToken(@Param("pushCluster") PushCluster pushCluster);
+
+	@Query("SELECT t FROM PushClusterToken t JOIN FETCH t.token tk JOIN FETCH tk.member WHERE t.pushCluster = :pushCluster")
+	List<PushClusterToken> findAllByPushClusterWithTokenAndMember(@Param("pushCluster") PushCluster pushCluster);
 }

--- a/src/main/java/com/example/ajouevent/repository/PushClusterTokenRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/PushClusterTokenRepository.java
@@ -1,0 +1,18 @@
+package com.example.ajouevent.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.example.ajouevent.domain.PushCluster;
+import com.example.ajouevent.domain.PushClusterToken;
+
+@Repository
+public interface PushClusterTokenRepository extends JpaRepository<PushClusterToken, Long> {
+
+	@Query("SELECT pct FROM PushClusterToken pct JOIN FETCH pct.token t WHERE pct.pushCluster = :pushCluster")
+	List<PushClusterToken> findAllByPushClusterWithToken(@Param("pushCluster") PushCluster pushCluster);
+}

--- a/src/main/java/com/example/ajouevent/repository/PushNotificationBulkRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/PushNotificationBulkRepository.java
@@ -1,0 +1,72 @@
+package com.example.ajouevent.repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.example.ajouevent.domain.PushNotification;
+
+@Repository
+public class PushNotificationBulkRepository {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+
+	public void saveAll(List<PushNotification> notifications) {
+		String sql = "INSERT INTO push_notification " +
+			"(push_cluster_id, member_id, topic_id, keyword_id, notification_type, title, body, image_url, click_url, is_read, notified_at, clicked_at) " +
+			"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				PushNotification notification = notifications.get(i);
+				ps.setLong(1, notification.getPushCluster() != null ? notification.getPushCluster().getId() : null); // push_cluster_id
+				ps.setLong(2, notification.getMember().getId()); // member_id
+				ps.setObject(3, notification.getTopic() != null ? notification.getTopic().getId() : null); // topic_id
+				ps.setObject(4, notification.getKeyword() != null ? notification.getKeyword().getId() : null); // keyword_id
+				ps.setString(5, notification.getNotificationType().name()); // notification_type
+				ps.setString(6, notification.getTitle()); // title
+				ps.setString(7, notification.getBody()); // body
+				ps.setString(8, notification.getImageUrl()); // image_url
+				ps.setString(9, notification.getClickUrl()); // click_url
+				ps.setBoolean(10, notification.isRead()); // is_read
+				ps.setTimestamp(11, Timestamp.valueOf(notification.getNotifiedAt())); // notified_at
+				ps.setTimestamp(12, notification.getClickedAt() != null ? Timestamp.valueOf(notification.getClickedAt()) : null); // clicked_at
+			}
+
+			@Override
+			public int getBatchSize() {
+				return notifications.size();
+			}
+		});
+	}
+
+	public void updateReadStatus(List<PushNotification> notifications) {
+		String sql = "UPDATE push_notification " +
+			"SET is_read = TRUE, clicked_at = ? " +
+			"WHERE id = ?";
+
+		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				PushNotification notification = notifications.get(i);
+				ps.setTimestamp(1, Timestamp.valueOf(LocalDateTime.now())); // 현재 시간으로 클릭 시간 설정
+				ps.setLong(2, notification.getId()); // 업데이트할 푸시 알림 ID
+			}
+
+			@Override
+			public int getBatchSize() {
+				return notifications.size();
+			}
+		});
+	}
+}

--- a/src/main/java/com/example/ajouevent/repository/PushNotificationRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/PushNotificationRepository.java
@@ -1,0 +1,24 @@
+package com.example.ajouevent.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.ajouevent.domain.Member;
+import com.example.ajouevent.domain.NotificationType;
+import com.example.ajouevent.domain.PushCluster;
+import com.example.ajouevent.domain.PushNotification;
+
+@Repository
+public interface PushNotificationRepository extends JpaRepository<PushNotification, Long> {
+	Optional<PushNotification> findByMemberAndId(Member member, Long id);
+
+	List<PushNotification> findAllByPushCluster(PushCluster pushCluster);
+
+	Slice<PushNotification> findByMemberAndNotificationType(Member member, NotificationType notificationType, Pageable pageable);
+	int countByMemberAndIsReadFalse(Member member);
+}

--- a/src/main/java/com/example/ajouevent/repository/PushNotificationRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/PushNotificationRepository.java
@@ -6,12 +6,15 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.ajouevent.domain.Member;
 import com.example.ajouevent.domain.NotificationType;
 import com.example.ajouevent.domain.PushCluster;
 import com.example.ajouevent.domain.PushNotification;
+import com.example.ajouevent.dto.UnreadNotificationCountDto;
 
 @Repository
 public interface PushNotificationRepository extends JpaRepository<PushNotification, Long> {
@@ -21,4 +24,20 @@ public interface PushNotificationRepository extends JpaRepository<PushNotificati
 
 	Slice<PushNotification> findByMemberAndNotificationType(Member member, NotificationType notificationType, Pageable pageable);
 	int countByMemberAndIsReadFalse(Member member);
+
+	@Query("SELECT new com.example.ajouevent.dto.UnreadNotificationCountDto(" +
+		"tm.member.id, CAST(COALESCE(COUNT(pn), 0) AS long)) " +  // 🔹 COUNT 결과를 long으로 변환
+		"FROM TopicMember tm " +
+		"LEFT JOIN PushNotification pn ON pn.member.id = tm.member.id AND pn.isRead = false " +
+		"WHERE tm.topic.koreanTopic = :koreanTopic " +
+		"GROUP BY tm.member.id")
+	List<UnreadNotificationCountDto> countUnreadNotificationsForTopic(@Param("koreanTopic") String koreanTopic);
+
+	@Query("SELECT new com.example.ajouevent.dto.UnreadNotificationCountDto(" +
+		"km.member.id, CAST(COALESCE(COUNT(pn), 0) AS long)) " +  // 🔹 COUNT 결과를 long으로 변환
+		"FROM KeywordMember km " +
+		"LEFT JOIN PushNotification pn ON pn.member.id = km.member.id AND pn.isRead = false " +
+		"WHERE km.keyword.encodedKeyword = :encodedKeyword " +
+		"GROUP BY km.member.id")
+	List<UnreadNotificationCountDto> countUnreadNotificationsForKeyword(@Param("encodedKeyword") String encodedKeyword);
 }

--- a/src/main/java/com/example/ajouevent/repository/TopicTokenRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/TopicTokenRepository.java
@@ -29,4 +29,7 @@ public interface TopicTokenRepository extends JpaRepository<TopicToken, Long> {
 	@Query("delete from TopicToken tt where tt.token.id in :tokenIds")
 	void deleteAllByTokenIds(@Param("tokenIds") List<Long> tokenIds);
 
+	@Query("SELECT tt FROM TopicToken tt JOIN FETCH tt.token t WHERE tt.topic = :topic AND t.isDeleted = false")
+	List<TopicToken> findByTopicWithValidTokens(@Param("topic") Topic topic);
+
 }

--- a/src/main/java/com/example/ajouevent/scheduler/PushClusterSyncScheduler.java
+++ b/src/main/java/com/example/ajouevent/scheduler/PushClusterSyncScheduler.java
@@ -1,0 +1,18 @@
+package com.example.ajouevent.scheduler;
+
+import com.example.ajouevent.service.PushClusterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PushClusterSyncScheduler {
+
+	private final PushClusterService pushClusterService;
+
+	@Scheduled(fixedRate = 60000) // 60초마다 실행
+	public void syncMetricsToDatabase() {
+		pushClusterService.syncMetricsToDatabase();
+	}
+}

--- a/src/main/java/com/example/ajouevent/service/PushClusterService.java
+++ b/src/main/java/com/example/ajouevent/service/PushClusterService.java
@@ -1,0 +1,129 @@
+package com.example.ajouevent.service;
+
+import com.example.ajouevent.domain.PushCluster;
+import com.example.ajouevent.domain.PushNotification;
+import com.example.ajouevent.dto.PushClusterStatsResponse;
+import com.example.ajouevent.logger.PushClusterLogger;
+import com.example.ajouevent.repository.PushClusterBulkRepository;
+import com.example.ajouevent.repository.PushClusterRepository;
+import com.example.ajouevent.repository.PushNotificationRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PushClusterService {
+
+	private final PushClusterRepository pushClusterRepository;
+	private final PushClusterBulkRepository pushClusterBulkRepository;
+	private final PushNotificationRepository pushNotificationRepository;
+	private final RedisService redisService;
+	private final PushClusterLogger pushClusterLogger;
+
+	public List<PushClusterStatsResponse> calculateAllPushClusterStats() {
+		List<PushCluster> pushClusters = pushClusterRepository.findAll();
+
+		return pushClusters.stream().map(this::	calculatePushClusterStats).collect(Collectors.toList());
+	}
+
+	private PushClusterStatsResponse calculatePushClusterStats(PushCluster pushCluster) {
+		int totalTokens = pushCluster.getTotalCount();
+		int successfulTokens = pushCluster.getSuccessCount();
+		int failedTokens = pushCluster.getFailCount();
+
+		// PushNotification 데이터 조회
+		List<PushNotification> notifications = pushNotificationRepository.findAllByPushCluster(pushCluster);
+		int totalNotifications = notifications.size();
+		int clickedNotifications = (int) notifications.stream().filter(PushNotification::isRead).count();
+
+		// 수신률 및 클릭률 계산
+		double deliveryRate = totalTokens > 0 ? (successfulTokens / (double) totalTokens) * 100 : 0;
+		double clickRate = totalNotifications > 0 ? (clickedNotifications / (double) totalNotifications) * 100 : 0;
+
+		return PushClusterStatsResponse.builder()
+			.pushClusterId(pushCluster.getId())
+			.title(pushCluster.getTitle())
+			.totalTokens(totalTokens)
+			.successfulTokens(successfulTokens)
+			.failedTokens(failedTokens)
+			.totalNotifications(totalNotifications)
+			.clickedNotifications(clickedNotifications)
+			.deliveryRate(deliveryRate)
+			.clickRate(clickRate)
+			.url(pushCluster.getClickUrl())
+			.jobStatus(pushCluster.getJobStatus().name())
+			.registerAt(pushCluster.getRegisteredAt())
+			.startAt(pushCluster.getStartAt())
+			.endAt(pushCluster.getEndAt())
+			.build();
+	}
+
+	// 수신 수 증가
+	public void incrementReceived(Long pushClusterId) {
+		redisService.incrementField(pushClusterId, "received");
+	}
+
+	// 클릭 수 증가
+	public void incrementClicked(Long pushClusterId) {
+		redisService.incrementField(pushClusterId, "clicked");
+	}
+
+	// Redis 데이터를 DB로 동기화
+	@Transactional
+	public void syncMetricsToDatabase() {
+		pushClusterLogger.log("PushCluster metrics sync started.");
+
+		// 모든 Redis 키를 가져옴
+		Set<String> keys = redisService.getKeysByPattern("pushCluster:*");
+		List<PushCluster> pushClustersToUpdate = new ArrayList<>();
+
+		for (String key : keys) {
+			// 키에서 PushCluster ID를 추출
+			String[] parts = key.split(":");
+			if (parts.length != 2) {
+				pushClusterLogger.log("Invalid Redis key format: {}" + key);
+				continue;
+			}
+
+			Long pushClusterId = Long.parseLong(parts[1]);
+
+			// Redis에서 데이터를 가져옴
+			Map<String, Integer> clusterData = redisService.getPushClusterData(pushClusterId);
+
+			// DB 업데이트
+			PushCluster pushCluster = pushClusterRepository.findById(pushClusterId)
+				.orElseThrow(() -> new IllegalArgumentException("Invalid PushCluster ID: " + pushClusterId));
+
+			int receivedCount = clusterData.getOrDefault("received", 0);
+			int clickedCount = clusterData.getOrDefault("clicked", 0);
+
+			pushCluster.setReceivedCount(pushCluster.getReceivedCount() + receivedCount);
+			pushCluster.setClickedCount(pushCluster.getClickedCount() + clickedCount);
+
+			pushClustersToUpdate.add(pushCluster);
+
+			// Redis 키 삭제
+			redisService.deletePushCluster(pushClusterId);
+		}
+
+		// Batch Update 실행
+		if (!pushClustersToUpdate.isEmpty()) {
+			pushClusterBulkRepository.updateAll(pushClustersToUpdate);
+		}
+
+		pushClusterLogger.log("PushCluster metrics sync completed.");
+	}
+
+
+}

--- a/src/main/java/com/example/ajouevent/service/PushNotificationService.java
+++ b/src/main/java/com/example/ajouevent/service/PushNotificationService.java
@@ -1,0 +1,367 @@
+package com.example.ajouevent.service;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import com.example.ajouevent.domain.ClubEvent;
+import com.example.ajouevent.domain.JobStatus;
+import com.example.ajouevent.domain.Keyword;
+import com.example.ajouevent.domain.KeywordMember;
+import com.example.ajouevent.domain.KeywordToken;
+import com.example.ajouevent.domain.Member;
+import com.example.ajouevent.domain.NotificationType;
+import com.example.ajouevent.domain.PushCluster;
+import com.example.ajouevent.domain.PushClusterToken;
+import com.example.ajouevent.domain.PushNotification;
+import com.example.ajouevent.domain.Topic;
+import com.example.ajouevent.domain.TopicMember;
+import com.example.ajouevent.domain.TopicToken;
+import com.example.ajouevent.dto.KeywordNotificationResponse;
+import com.example.ajouevent.dto.NoticeDto;
+import com.example.ajouevent.dto.NotificationClickRequest;
+import com.example.ajouevent.dto.SliceResponse;
+import com.example.ajouevent.dto.TopicNotificationResponse;
+import com.example.ajouevent.dto.UnreadNotificationCountResponse;
+import com.example.ajouevent.exception.CustomErrorCode;
+import com.example.ajouevent.exception.CustomException;
+import com.example.ajouevent.repository.EventRepository;
+import com.example.ajouevent.repository.KeywordMemberRepository;
+import com.example.ajouevent.repository.KeywordRepository;
+import com.example.ajouevent.repository.KeywordTokenRepository;
+import com.example.ajouevent.repository.MemberRepository;
+import com.example.ajouevent.repository.PushClusterRepository;
+import com.example.ajouevent.repository.PushClusterTokenBulkRepository;
+import com.example.ajouevent.repository.PushNotificationBulkRepository;
+import com.example.ajouevent.repository.PushNotificationRepository;
+import com.example.ajouevent.repository.TopicMemberRepository;
+import com.example.ajouevent.repository.TopicRepository;
+import com.example.ajouevent.repository.TopicTokenRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PushNotificationService {
+
+	private static final String DEFAULT_IMAGE_URL = "https://www.ajou.ac.kr/_res/ajou/kr/img/intro/img-symbol.png";
+	private static final String REDIRECTION_URL_PREFIX = "https://www.ajouevent.com/event/";
+	private static final String DEFAULT_CLICK_ACTION_URL =  "https://www.ajouevent.com";
+
+	private final TopicRepository topicRepository;
+	private final TopicMemberRepository topicMemberRepository;
+	private final PushClusterRepository pushClusterRepository;
+	private final PushNotificationRepository pushNotificationRepository;
+	private final PushClusterTokenBulkRepository pushClusterTokenBulkRepository;
+	private final EventRepository eventRepository;
+	private final TopicTokenRepository topicTokenRepository;
+	private final KeywordTokenRepository keywordTokenRepository;
+	private final KeywordRepository keywordRepository;
+	private final KeywordMemberRepository keywordMemberRepository;
+	private final MemberRepository memberRepository;
+	private final FCMService fcmService;
+	private final PushNotificationBulkRepository pushNotificationBulkRepository;
+
+	@Transactional
+	public Long postPushNotification(NoticeDto noticeDto, Long eventId) {
+
+		// 푸시 알림 메시지 구성
+		String title = composeMessageTitle(noticeDto);
+		String body = composeBody(noticeDto);
+		String imageUrl = getFirstImageUrl(noticeDto);
+		String clickUrl = getRedirectionUrl(noticeDto, eventId);
+
+		// Topic 찾기
+		Topic topic = topicRepository.findByDepartment(noticeDto.getEnglishTopic())
+			.orElseThrow(() -> new CustomException(CustomErrorCode.TOPIC_NOT_FOUND));
+
+		// Topic을 구독 중인 TopicMember 조회
+		List<TopicMember> topicMembers = topicMemberRepository.findByTopic(topic);
+
+		// Topic을 구독 중인 TopicToken 조회 (isDeleted가 false)
+		List<TopicToken> topicTokens = topicTokenRepository.findByTopicWithValidTokens(topic);
+
+		// ClubEvent 조회
+		ClubEvent clubEvent = eventRepository.findById(eventId)
+			.orElseThrow(() -> new CustomException(CustomErrorCode.EVENT_NOT_FOUND));
+
+		// PushCluster 생성
+		PushCluster pushCluster = PushCluster.builder()
+			.clubEvent(clubEvent)
+			.title(title)
+			.body(body)
+			.imageUrl(imageUrl)
+			.clickUrl(clickUrl)
+			.totalCount(topicTokens.size())
+			.registeredAt(LocalDateTime.now())
+			.jobStatus(JobStatus.PENDING)
+			.build();
+		pushClusterRepository.save(pushCluster);
+
+		// 이 시점에서 pushCluster.getId()를 바로 사용할 수 있음
+		Long pushClusterId = pushCluster.getId();
+		log.info("토픽에서 - Generated PushCluster ID: {}", pushClusterId);
+
+		// PushClusterTokens 생성
+		List<PushClusterToken> clusterTokens = topicTokens.stream()
+			.map(token -> PushClusterToken.builder()
+				.pushCluster(pushCluster)
+				.token(token.getToken()) // TopicToken에 연결된 Token 가져오기
+				.jobStatus(JobStatus.PENDING) // 초기 상태: PENDING
+				.requestTime(LocalDateTime.now()) // 요청 시간 기록
+				.build())
+			.collect(Collectors.toList());
+		pushClusterTokenBulkRepository.saveAll(clusterTokens);
+
+		// PushNotifications 생성
+		List<PushNotification> notifications = topicMembers.stream()
+			.map(member -> PushNotification.builder()
+				.pushCluster(pushCluster)
+				.member(member.getMember())
+				.topic(topic)
+				.title(title)
+				.body(body)
+				.imageUrl(imageUrl)
+				.clickUrl(clickUrl)
+				.notificationType(NotificationType.TOPIC)
+				.notifiedAt(LocalDateTime.now())
+				.build())
+			.collect(Collectors.toList());
+		pushNotificationBulkRepository.saveAll(notifications);
+
+		return pushCluster.getId(); // PushCluster ID 반환
+	}
+
+	private String composeMessageTitle(NoticeDto noticeDto) {
+		return String.format("[%s]", noticeDto.getKoreanTopic());
+	}
+
+	private String composeBody(NoticeDto noticeDto) {
+		return noticeDto.getTitle();
+	}
+
+	private String getFirstImageUrl(NoticeDto noticeDto) {
+		List<String> images = Optional.ofNullable(noticeDto.getImages())
+			.filter(imgs -> !imgs.isEmpty())
+			.orElseGet(() -> {
+				List<String> defaultImages = new ArrayList<>();
+				defaultImages.add(DEFAULT_IMAGE_URL);
+				return defaultImages;
+			});
+		return images.get(0);
+	}
+
+	private String getRedirectionUrl(NoticeDto noticeDto, Long eventId) {
+		String url = Optional.ofNullable(noticeDto.getUrl())
+			.filter(u -> !u.isEmpty())
+			.map(u -> REDIRECTION_URL_PREFIX + eventId) // 크롤링 후 DB에 저장된, 우리 앱 상세페이지로 이동
+			.orElse(DEFAULT_CLICK_ACTION_URL);
+		log.info("리다이렉션하는 URL: {}", url);
+		return url;
+	}
+
+	@Transactional
+	public void handleKeywordPushNotification(NoticeDto noticeDto, Long eventId) {
+
+		// Topic 찾기
+		Topic topic = topicRepository.findByDepartment(noticeDto.getEnglishTopic())
+			.orElseThrow(() -> new CustomException(CustomErrorCode.TOPIC_NOT_FOUND));
+
+		// 해당 Topic에 설정된 모든 Keyword 가져오기
+		List<Keyword> keywords = keywordRepository.findByTopic(topic);
+
+		// 크롤링된 제목에서 키워드 매칭
+		List<Keyword> matchedKeywords = keywords.stream()
+			.filter(keyword -> noticeDto.getTitle().contains(keyword.getKoreanKeyword()))
+			.collect(Collectors.toList());
+
+		if (matchedKeywords.isEmpty()) {
+			log.info("매칭된 키워드가 없습니다. 푸시 알림을 발송하지 않습니다.");
+			return;
+		}
+
+		// ClubEvent 조회
+		ClubEvent clubEvent = eventRepository.findById(eventId)
+			.orElseThrow(() -> new CustomException(CustomErrorCode.EVENT_NOT_FOUND));
+
+		for (Keyword keyword : matchedKeywords) {
+			String title = keyword.getKoreanKeyword() + "-" + composeMessageTitle(noticeDto);
+			String body = composeBody(noticeDto);
+			String imageUrl = getFirstImageUrl(noticeDto);
+			String clickUrl = getRedirectionUrl(noticeDto, eventId);
+
+			// 해당 키워드에 구독된 사용자 조회
+			List<KeywordMember> keywordMembers = keywordMemberRepository.findByKeyword(keyword);
+			List<KeywordToken> keywordTokens = keywordTokenRepository.findKeywordTokensWithTokenByKeyword(keyword);
+
+			// PushCluster 생성
+			PushCluster pushCluster = PushCluster.builder()
+				.clubEvent(clubEvent)
+				.title(title)
+				.body(body)
+				.imageUrl(imageUrl)
+				.clickUrl(clickUrl)
+				.totalCount(keywordTokens.size())
+				.registeredAt(LocalDateTime.now())
+				.jobStatus(JobStatus.PENDING)
+				.build();
+			pushClusterRepository.save(pushCluster);
+
+			// 이 시점에서 pushCluster.getId()를 바로 사용할 수 있음
+			Long pushClusterId = pushCluster.getId();
+			log.info("키워드에서 - Generated PushCluster ID: {}", pushClusterId);
+
+			// PushClusterToken 생성
+			List<PushClusterToken> clusterTokens = keywordTokens.stream()
+				.map(token -> PushClusterToken.builder()
+					.pushCluster(pushCluster)
+					.token(token.getToken())
+					.jobStatus(JobStatus.PENDING)
+					.requestTime(LocalDateTime.now())
+					.build())
+				.collect(Collectors.toList());
+
+			// PushNotification 생성
+			List<PushNotification> notifications = keywordMembers.stream()
+				.map(member -> PushNotification.builder()
+					.pushCluster(pushCluster)
+					.member(member.getMember())
+					.keyword(keyword)
+					.title(title)
+					.body(body)
+					.imageUrl(imageUrl)
+					.topic(topic)
+					.clickUrl(clickUrl)
+					.notificationType(NotificationType.KEYWORD)
+					.notifiedAt(LocalDateTime.now())
+					.build())
+				.collect(Collectors.toList());
+			pushNotificationBulkRepository.saveAll(notifications);
+
+			// FCM 푸시 알림 전송
+			fcmService.sendKeywordPushNotification(clusterTokens, pushCluster, keyword, noticeDto, eventId);
+
+		}
+	}
+
+	// Topic 알림 조회
+	@Transactional
+	public SliceResponse<TopicNotificationResponse> getTopicNotificationsForMember(Pageable pageable) {
+		Member member = getAuthenticatedMember();
+		return getTopicNotifications(member, pageable);
+	}
+
+	// Keyword 알림 조회
+	@Transactional
+	public SliceResponse<KeywordNotificationResponse> getKeywordNotificationsForMember(Pageable pageable) {
+		Member member = getAuthenticatedMember();
+		return getKeywordNotifications(member, pageable);
+	}
+
+	private SliceResponse<TopicNotificationResponse> getTopicNotifications(Member member, Pageable pageable) {
+		Slice<PushNotification> notificationSlice = pushNotificationRepository.findByMemberAndNotificationType(member, NotificationType.TOPIC, pageable);
+
+		// 기존에 조회한 데이터에서 읽지 않은 알림만 필터링
+		List<PushNotification> unreadNotifications = notificationSlice.getContent()
+			.stream()
+			.filter(notification -> !notification.isRead()) // 읽지 않은 알림만 선택
+			.toList();
+
+		if (!unreadNotifications.isEmpty()) {
+			pushNotificationBulkRepository.updateReadStatus(unreadNotifications);
+		}
+
+		List<TopicNotificationResponse> responseList = notificationSlice.getContent().stream()
+			.map(TopicNotificationResponse::toDto)
+			.collect(Collectors.toList());
+
+		return new SliceResponse<>(
+			responseList,
+			notificationSlice.hasPrevious(),
+			notificationSlice.hasNext(),
+			notificationSlice.getNumber(),
+			createSortResponse(pageable)
+		);
+	}
+
+	private SliceResponse<KeywordNotificationResponse> getKeywordNotifications(Member member, Pageable pageable) {
+		Slice<PushNotification> notificationSlice = pushNotificationRepository.findByMemberAndNotificationType(member, NotificationType.KEYWORD, pageable);
+
+		// 기존에 조회한 데이터에서 읽지 않은 알림만 필터링
+		List<PushNotification> unreadNotifications = notificationSlice.getContent()
+			.stream()
+			.filter(notification -> !notification.isRead()) // 읽지 않은 알림만 선택
+			.toList();
+
+		if (!unreadNotifications.isEmpty()) {
+			pushNotificationBulkRepository.updateReadStatus(unreadNotifications);
+		}
+
+		List<KeywordNotificationResponse> responseList = notificationSlice.getContent().stream()
+			.map(KeywordNotificationResponse::toDto)
+			.collect(Collectors.toList());
+
+		return new SliceResponse<>(
+			responseList,
+			notificationSlice.hasPrevious(),
+			notificationSlice.hasNext(),
+			notificationSlice.getNumber(),
+			createSortResponse(pageable)
+		);
+	}
+
+	private SliceResponse.SortResponse createSortResponse(Pageable pageable) {
+		return SliceResponse.SortResponse.builder()
+			.sorted(pageable.getSort().isSorted())
+			.direction(String.valueOf(pageable.getSort().descending()))
+			.orderProperty(pageable.getSort().stream().map(Sort.Order::getProperty).findFirst().orElse(null))
+			.build();
+	}
+
+	private Member getAuthenticatedMember() {
+		String memberEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+		return memberRepository.findByEmailWithTokens(memberEmail)
+			.orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
+	}
+
+	@Transactional
+	public void markNotificationAsRead(NotificationClickRequest notificationClickRequest) {
+		String memberEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+
+		Member member = memberRepository.findByEmailWithTokens(memberEmail)
+			.orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
+
+		PushNotification notification = pushNotificationRepository.findByMemberAndId(member, notificationClickRequest.getPushNotificationId())
+			.orElseThrow(() -> new CustomException(CustomErrorCode.PUSH_NOTIFICATION_NOT_FOUND));
+
+		notification.markAsRead();
+		pushNotificationRepository.save(notification);
+	}
+
+	@Transactional
+	public UnreadNotificationCountResponse getUnreadNotificationCount(Principal principal) {
+		String memberEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+
+		Member member = memberRepository.findByEmailWithTokens(memberEmail)
+			.orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
+
+		int unreadNotificationCount = pushNotificationRepository.countByMemberAndIsReadFalse(member);
+
+		return UnreadNotificationCountResponse.builder()
+			.unreadNotificationCount(unreadNotificationCount)
+			.build();
+	}
+
+}

--- a/src/main/java/com/example/ajouevent/service/RedisService.java
+++ b/src/main/java/com/example/ajouevent/service/RedisService.java
@@ -2,7 +2,10 @@ package com.example.ajouevent.service;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -66,6 +69,35 @@ public class RedisService {
 	public boolean isTokenValid(String key, String token) {
 		String storedToken = stringRedisTemplate.opsForValue().get(key);
 		return token.equals(storedToken);
+	}
+
+	// 수신, 클릭 수를 증가시킴
+	public void incrementField(Long pushClusterId, String field) {
+		String redisKey = "pushCluster:" + pushClusterId;
+		stringRedisTemplate.opsForHash().increment(redisKey, field, 1);
+	}
+
+	// 특정 PushCluster의 모든 데이터를 가져옴
+	public Map<String, Integer> getPushClusterData(Long pushClusterId) {
+		String redisKey = "pushCluster:" + pushClusterId;
+		return stringRedisTemplate.opsForHash()
+			.entries(redisKey)
+			.entrySet()
+			.stream()
+			.collect(Collectors.toMap(
+				entry -> (String) entry.getKey(),
+				entry -> Integer.valueOf((String) entry.getValue())
+			));
+	}
+
+	// Redis 키를 삭제
+	public void deletePushCluster(Long pushClusterId) {
+		String redisKey = "pushCluster:" + pushClusterId;
+		stringRedisTemplate.delete(redisKey);
+	}
+
+	public Set<String> getKeysByPattern(String pattern) {
+		return stringRedisTemplate.keys(pattern);
 	}
 
 


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#67)

## 💻 작업 내용

> (작업내용작성)

- [x] 웹훅 방식 Facade 패턴 변경
- [x] Topic 방식의 FCM 메시지 발송 -> sendEachAsync로
- [x] PushCluster를 통한 푸시 알림 통계 확인
- [x] PushNotification을 통한 푸시 알림 목록 확인 (안 읽은 푸시 알림 개수 확인 가능)
- [x] 푸시 알림 데이터에 안읽은 알림 개수 포함
- [x] 성공, 실패 카운트 배치 처리 고려 (누적 처리)

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
