### PR TITLE
feat: 구독중에서 알림 여부 설정 추가 

### DIFF
--- a/src/main/java/com/example/ajouevent/controller/TopicController.java
+++ b/src/main/java/com/example/ajouevent/controller/TopicController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.ajouevent.dto.NotificationPreferenceRequest;
 import com.example.ajouevent.dto.ResponseDto;
 import com.example.ajouevent.dto.TopicDetailResponse;
 import com.example.ajouevent.dto.TopicRequest;
@@ -78,5 +79,16 @@ public class TopicController {
 	@GetMapping("/subscriptionsStatus")
 	public List<TopicStatus> getTopicWithUserSubscriptionsStatus(Principal principal) {
 		return topicService.getTopicWithUserSubscriptionsStatus(principal);
+	}
+
+	@PreAuthorize("isAuthenticated()")
+	@PostMapping("/subscriptions/notification")
+	public ResponseEntity<ResponseDto> updateNotificationPreference(@RequestBody NotificationPreferenceRequest request) {
+		topicService.updateNotificationPreference(request);
+		return ResponseEntity.ok().body(ResponseDto.builder()
+			.successStatus(HttpStatus.OK)
+			.successContent(request.getTopic() + " 알림 수신 설정이 " + request.isReceiveNotification() + "로 변경되었습니다.")
+			.build()
+		);
 	}
 }

--- a/src/main/java/com/example/ajouevent/domain/TopicMember.java
+++ b/src/main/java/com/example/ajouevent/domain/TopicMember.java
@@ -40,4 +40,7 @@ public class TopicMember {
 
 	@Column(nullable = false)
 	private LocalDateTime lastReadAt;
+
+	@Column(nullable = false, columnDefinition = "TINYINT(1)")
+	private boolean receiveNotification;
 }

--- a/src/main/java/com/example/ajouevent/dto/NotificationPreferenceRequest.java
+++ b/src/main/java/com/example/ajouevent/dto/NotificationPreferenceRequest.java
@@ -1,0 +1,9 @@
+package com.example.ajouevent.dto;
+
+import lombok.Data;
+
+@Data
+public class NotificationPreferenceRequest {
+	private String topic;
+	private boolean receiveNotification;
+}

--- a/src/main/java/com/example/ajouevent/dto/TopicStatus.java
+++ b/src/main/java/com/example/ajouevent/dto/TopicStatus.java
@@ -16,4 +16,5 @@ public class TopicStatus {
 	private final String classification;
 	private final boolean subscribed;
 	private final Long koreanOrder;
+	private final boolean receiveNotification;
 }

--- a/src/main/java/com/example/ajouevent/repository/TopicMemberRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/TopicMemberRepository.java
@@ -40,4 +40,10 @@ public interface TopicMemberRepository extends JpaRepository<TopicMember, Long> 
 
 	boolean existsByMemberAndIsReadFalse(Member member);
 
+	@Query("SELECT tm FROM TopicMember tm JOIN FETCH tm.member m JOIN FETCH m.tokens t WHERE tm.topic = :topic AND tm.receiveNotification = true ")
+	List<TopicMember> findByTopicWithNotificationEnabledAndTokens(@Param("topic") Topic topic);
+
+	@Query("SELECT tm.receiveNotification FROM TopicMember tm WHERE tm.member = :member AND tm.topic = :topic")
+	boolean findReceiveNotificationByMemberAndTopic(@Param("member") Member member, @Param("topic") Topic topic);
+
 }

--- a/src/main/java/com/example/ajouevent/repository/TopicTokenRepository.java
+++ b/src/main/java/com/example/ajouevent/repository/TopicTokenRepository.java
@@ -32,4 +32,15 @@ public interface TopicTokenRepository extends JpaRepository<TopicToken, Long> {
 	@Query("SELECT tt FROM TopicToken tt JOIN FETCH tt.token t WHERE tt.topic = :topic AND t.isDeleted = false")
 	List<TopicToken> findByTopicWithValidTokens(@Param("topic") Topic topic);
 
+	@Query("""
+	    SELECT tt FROM TopicToken tt
+	    JOIN FETCH tt.token t
+	    JOIN t.member m
+	    JOIN TopicMember tm ON tm.member = m AND tm.topic = :topic
+	    WHERE tt.topic = :topic
+	    AND t.isDeleted = false
+	    AND tm.receiveNotification = true
+	""")
+	List<TopicToken> findByTopicWithValidTokensAndReceiveNotificationTrue(@Param("topic") Topic topic);
+
 }

--- a/src/main/java/com/example/ajouevent/service/PushNotificationService.java
+++ b/src/main/java/com/example/ajouevent/service/PushNotificationService.java
@@ -87,11 +87,11 @@ public class PushNotificationService {
 		Topic topic = topicRepository.findByDepartment(noticeDto.getEnglishTopic())
 			.orElseThrow(() -> new CustomException(CustomErrorCode.TOPIC_NOT_FOUND));
 
-		// Topic을 구독 중인 TopicMember 조회
-		List<TopicMember> topicMembers = topicMemberRepository.findByTopic(topic);
+		// Topic을 구독 중이고, 알림을 수신 허용한 TopicMember 조회
+		List<TopicMember> topicMembers = topicMemberRepository.findByTopicWithNotificationEnabledAndTokens(topic);
 
 		// Topic을 구독 중인 TopicToken 조회 (isDeleted가 false)
-		List<TopicToken> topicTokens = topicTokenRepository.findByTopicWithValidTokens(topic);
+		List<TopicToken> topicTokens = topicTokenRepository.findByTopicWithValidTokensAndReceiveNotificationTrue(topic);
 
 		// ClubEvent 조회
 		ClubEvent clubEvent = eventRepository.findById(eventId)


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#61 )

## 💻 작업 내용

- [x] 구독은 하는데, 푸시 알림은 받지 않는 옵션 추가
- [x] 크롤링한 공지사항에 대한 알림 목록에도 알림을 받지 않는다면 넣지 않음
- [x] 알림 설정이 변경되더라도 구독 상태는 그대로


### 테스트 결과 or 스크린샷 (선택)

https://github.com/user-attachments/assets/b89e4543-088f-4530-bec0-20fb762a29a6


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
