### PR TITLE
refactor: 게시글 조회수 증가 관련 로직을 EventViewService로 분리하여 책임 분리(#99)

### DIFF
--- a/src/main/java/com/example/ajouevent/service/EventCommandService.java
+++ b/src/main/java/com/example/ajouevent/service/EventCommandService.java
@@ -6,11 +6,9 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.http.ResponseCookie;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,8 +37,6 @@ import com.example.ajouevent.repository.TopicMemberRepository;
 import com.example.ajouevent.repository.TopicRepository;
 import com.example.ajouevent.util.JsonParsingUtil;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -432,60 +428,6 @@ public class EventCommandService {
 
 		// 게시글 삭제 후 해당 타입의 캐시 초기화
 		jsonParsingUtil.clearCacheForType(clubEvent.getType().getEnglishTopic());
-	}
-
-	public void handleAnonymousUserWithCookieAndRedis(HttpServletRequest request, HttpServletResponse response, ClubEvent clubEvent) {
-		String ipAddress = getClientIp(request);
-		String userAgent = request.getHeader("User-Agent");
-		String currentCookieValue = cookieService.getCookieValue(request, clubEvent);
-
-		// Redis 키 생성
-		String redisKey = "ClubEvent_View:" + clubEvent.getEventId() + ":" + ipAddress + ":" + userAgent;
-
-		// 쿠키가 없거나 조회된 적 없는 경우
-		if (!cookieService.isAlreadyViewed(currentCookieValue, clubEvent.getEventId())) {
-			ResponseCookie newCookie = cookieService.createOrUpdateCookie(currentCookieValue, clubEvent);
-			response.addHeader("Set-Cookie", newCookie.toString());
-
-			// 쿠키가 없으면 Redis에서 한 번 더 확인
-			if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(redisKey))) {
-				stringRedisTemplate.opsForValue().set(redisKey, "0", 86400L, TimeUnit.SECONDS); // TTL과 함께 설정
-
-				// 조회수 증가
-				increaseViews(clubEvent);
-			}
-		}
-	}
-
-	public String getClientIp(HttpServletRequest request) {
-		String ip = request.getHeader("X-Forwarded-For");
-		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-			ip = request.getHeader("Proxy-Client-IP");
-		}
-		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-			ip = request.getHeader("WL-Proxy-Client-IP");
-		}
-		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-			ip = request.getRemoteAddr();
-		}
-		return ip.split(",")[0].trim(); // X-Forwarded-For는 콤마로 구분된 여러 IP를 가질 수 있음
-	}
-
-	public void handleAuthenticatedUser(String userId, ClubEvent clubEvent) {
-		if (redisService.isFirstIpRequest(userId, clubEvent.getEventId(), clubEvent)) {
-			redisService.writeClientRequest(userId, clubEvent.getEventId(), clubEvent);
-			increaseViews(clubEvent);
-		}
-	}
-
-	public void increaseViews(ClubEvent clubEvent){
-		String key = "ClubEvent:views:" + clubEvent.getEventId();
-		Boolean exist = stringRedisTemplate.opsForValue().setIfAbsent(key, String.valueOf(clubEvent.getViewCount()+1),4L,
-			TimeUnit.MINUTES);
-		if(Boolean.FALSE.equals(exist)){
-			stringRedisTemplate.opsForValue().increment(key);
-			stringRedisTemplate.expire(key,4L,TimeUnit.MINUTES);
-		}
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/example/ajouevent/service/EventFacadeService.java
+++ b/src/main/java/com/example/ajouevent/service/EventFacadeService.java
@@ -6,14 +6,12 @@ import org.springframework.data.domain.Pageable;
 
 import org.springframework.stereotype.Service;
 
-import com.example.ajouevent.domain.ClubEvent;
 import com.example.ajouevent.dto.EventDetailResponseDto;
 import com.example.ajouevent.dto.EventResponseDto;
 import com.example.ajouevent.dto.EventWithKeywordDto;
 import com.example.ajouevent.dto.SliceResponse;
 import com.example.ajouevent.exception.CustomErrorCode;
 import com.example.ajouevent.exception.CustomException;
-import com.example.ajouevent.repository.EventRepository;
 import com.example.ajouevent.util.SecurityUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,22 +21,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class EventFacadeService {
 	private final EventQueryService eventQueryService;
-	private final EventCommandService eventCommandService;
-	private final EventRepository eventRepository;
+	private final EventViewService eventViewService;
 	private final TopicService topicService;
 	private final KeywordService keywordService;
 
 	// 이벤트 상세 조회 및 조회수 증가
 	public EventDetailResponseDto getEventDetail(Long eventId, Principal principal, HttpServletRequest request, HttpServletResponse response) {
-		ClubEvent clubEvent = eventRepository.findById(eventId)
-			.orElseThrow(() -> new CustomException(CustomErrorCode.EVENT_NOT_FOUND));
-
 		String userId = SecurityUtil.getCurrentMemberUsernameOrAnonymous();
 
 		if (isAnonymous(userId)) {
-			eventCommandService.handleAnonymousUserWithCookieAndRedis(request, response, clubEvent);
+			eventViewService.handleAnonymousUser(request, response, eventId);
 		} else {
-			eventCommandService.handleAuthenticatedUser(userId, clubEvent);
+			eventViewService.handleAuthenticatedUser(userId, eventId);
 		}
 
 		return eventQueryService.getEventDetail(eventId, principal);

--- a/src/main/java/com/example/ajouevent/service/EventViewService.java
+++ b/src/main/java/com/example/ajouevent/service/EventViewService.java
@@ -1,0 +1,91 @@
+package com.example.ajouevent.service;
+
+import com.example.ajouevent.domain.ClubEvent;
+import com.example.ajouevent.exception.CustomErrorCode;
+import com.example.ajouevent.exception.CustomException;
+import com.example.ajouevent.repository.EventRepository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EventViewService {
+
+	private final CookieService cookieService;
+	private final RedisService redisService;
+	private final StringRedisTemplate stringRedisTemplate;
+	private final EventRepository eventRepository;
+
+	// 익명 사용자 처리
+	public void handleAnonymousUser(HttpServletRequest request, HttpServletResponse response, Long eventId) {
+		ClubEvent clubEvent = getClubEvent(eventId);
+
+		String ipAddress = getClientIp(request);
+		String userAgent = request.getHeader("User-Agent");
+		String cookieValue = cookieService.getCookieValue(request, clubEvent);
+
+		// Redis 키 생성
+		String redisKey = "ClubEvent_View:" + clubEvent.getEventId() + ":" + ipAddress + ":" + userAgent;
+
+		// 쿠키가 없거나 조회된 적 없는 경우
+		if (!cookieService.isAlreadyViewed(cookieValue, clubEvent.getEventId())) {
+			ResponseCookie newCookie = cookieService.createOrUpdateCookie(cookieValue, clubEvent);
+			response.addHeader("Set-Cookie", newCookie.toString());
+
+			// 쿠키가 없으면 Redis에서 한 번 더 확인
+			if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(redisKey))) {
+				stringRedisTemplate.opsForValue().set(redisKey, "0", 86400L, TimeUnit.SECONDS); // TTL과 함께 설정
+
+				// 조회수 증가
+				increaseViews(clubEvent);
+			}
+		}
+	}
+
+	// 로그인 사용자 처리
+	public void handleAuthenticatedUser(String userId, Long eventId) {
+		ClubEvent clubEvent = getClubEvent(eventId);
+		if (redisService.isFirstIpRequest(userId, clubEvent.getEventId(), clubEvent)) {
+			redisService.writeClientRequest(userId, clubEvent.getEventId(), clubEvent);
+			increaseViews(clubEvent);
+		}
+	}
+
+	// 조회수 증가
+	public void increaseViews(ClubEvent clubEvent){
+		String key = "ClubEvent:views:" + clubEvent.getEventId();
+		Boolean exist = stringRedisTemplate.opsForValue().setIfAbsent(key, String.valueOf(clubEvent.getViewCount()+1),4L, TimeUnit.MINUTES);
+		if(Boolean.FALSE.equals(exist)){
+			stringRedisTemplate.opsForValue().increment(key);
+			stringRedisTemplate.expire(key,4L,TimeUnit.MINUTES);
+		}
+	}
+
+	private String getClientIp(HttpServletRequest request) {
+		String ip = request.getHeader("X-Forwarded-For");
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("Proxy-Client-IP");
+		}
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("WL-Proxy-Client-IP");
+		}
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getRemoteAddr();
+		}
+		return ip.split(",")[0].trim(); // X-Forwarded-For는 콤마로 구분된 여러 IP를 가질 수 있음
+	}
+
+	private ClubEvent getClubEvent(Long eventId) {
+		return eventRepository.findById(eventId)
+			.orElseThrow(() -> new CustomException(CustomErrorCode.EVENT_NOT_FOUND));
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#99)

## 💻 작업 내용

> (작업내용작성)

- [ ] 조회수 증가 로직 increaseViews() 분리
- [ ] 익명 사용자 처리 → handleAnonymousUser() 분리
- [ ] 로그인 사용자 처리 → handleAuthenticatedUser() 분리
- [ ] EventCommandService에서 해당 메서드 제거 및 리팩토링

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)

> EventCommandService에서 조회수 처리 관련을 EventViewService로 분리했는데, 
EventViewService 내부에서도 ViewCountPolicy 클래스를 두고, CookieViewService(비로그인, 쿠키로 조회수 중복 처리), RedisViewService(로그인, Redis로 조회수 중복 처리)를 나눠야할지 고민입니다.

생각한 구조

EventViewService
├── ViewCountPolicy
 │   ├── AnonymousViewPolicy
 │   └── AuthenticatedViewPolicy
├── CookieViewService
└── RedisViewService
