### PR TITLE
[Refactor] 크롤링한 공지사항 저장 및 푸시 알림 발송 프로세스 리팩토링

### DIFF
--- a/src/main/java/com/example/ajouevent/domain/PushCluster.java
+++ b/src/main/java/com/example/ajouevent/domain/PushCluster.java
@@ -1,6 +1,7 @@
 package com.example.ajouevent.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.persistence.CascadeType;
@@ -77,7 +78,15 @@ public class PushCluster {
 	private LocalDateTime endAt = LocalDateTime.now(); // 작업 종료 시간
 
 	@OneToMany(mappedBy = "pushCluster", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<PushClusterToken> tokens; // 발송 작업에 포함된 토큰들
+	private List<PushClusterToken> tokens = new ArrayList<>(); // 발송 작업에 포함된 토큰들
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "topic_id")
+	private Topic topic;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "keyword_id")
+	private Keyword keyword;
 
 	// 작업 시작 기록
 	public void markAsInProgress() {

--- a/src/main/java/com/example/ajouevent/facade/WebhookFacade.java
+++ b/src/main/java/com/example/ajouevent/facade/WebhookFacade.java
@@ -1,5 +1,8 @@
 package com.example.ajouevent.facade;
 
+import com.example.ajouevent.domain.ClubEvent;
+import com.example.ajouevent.domain.PushCluster;
+import com.example.ajouevent.service.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -8,14 +11,12 @@ import com.example.ajouevent.dto.NoticeDto;
 import com.example.ajouevent.dto.WebhookResponse;
 import com.example.ajouevent.exception.CustomException;
 import com.example.ajouevent.logger.WebhookLogger;
-import com.example.ajouevent.service.EventCommandService;
-import com.example.ajouevent.service.FCMService;
-import com.example.ajouevent.service.PushNotificationService;
-import com.example.ajouevent.service.RedisService;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -26,16 +27,16 @@ public class WebhookFacade {
 	private final EventCommandService eventCommandService;
 	private final FCMService fcmService;
 	private final PushNotificationService pushNotificationService;
+	private final PushClusterService pushClusterService;
 	private final WebhookLogger webhookLogger;
 
-	@Transactional
 	public ResponseEntity<WebhookResponse> processWebhook(String token, NoticeDto noticeDto) {
-		try {
-			// 토큰 검증
-			if (!redisService.isTokenValid("crawling-token", token)) {
-				return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-			}
+		// 크롤링 인증 토큰 검증
+		if (!redisService.isTokenValid("crawling-token", token)) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
 
+		try {
 			// 공지사항 중복 여부 확인 - 공지사항 제목, 원래 공지사항 url 비교
 			boolean isDuplicate = eventCommandService.isDuplicateNotice(noticeDto.getEnglishTopic(), noticeDto.getTitle(), noticeDto.getUrl());
 			if (isDuplicate) {
@@ -50,23 +51,41 @@ public class WebhookFacade {
 			}
 
 			// 크롤링한 공지사항을 DB에 저장
-			Long eventId = eventCommandService.postNotice(noticeDto);
+			ClubEvent clubEvent = eventCommandService.postNotice(noticeDto);
 
-			// 알림을 구독자별로 PushNotifications에 미리 저장
-			Long pushClusterId = pushNotificationService.postPushNotification(noticeDto, eventId);
+			// 토픽/키워드별 PushCluster 준비: 토픽 및 키워드별 푸시 알림 전송을 위한
+			PushCluster topicCluster = pushClusterService.prepareTopicCluster(noticeDto, clubEvent);
+			List<PushCluster> keywordClusters = pushClusterService.prepareKeywordClusters(noticeDto, clubEvent);
 
-			// 공지사항 Topic을 구독하고있는 사용자한테 FCM 메시지 전송
-			fcmService.sendNoticeNotification(noticeDto, eventId, pushClusterId);
+			// 사용자별 푸시 알림 미리 DB에 저장
+			pushNotificationService.saveTopicNotifications(topicCluster);
+			pushNotificationService.saveKeywordNotifications(keywordClusters);
 
-			pushNotificationService.handleKeywordPushNotification(noticeDto, eventId);
+			if (topicCluster.getTotalCount() > 0) {
+				// 사용자별 읽지 않은 알림 개수 조회
+				Map<Long, Long> unreadCountMap = pushNotificationService.getUnreadNotificationCountMapForTopic(topicCluster.getTopic().getKoreanTopic());
 
-			WebhookResponse response = WebhookResponse.builder()
-				.result("Webhook processed successfully.")
-				.eventId(eventId)
-				.topic(noticeDto.getEnglishTopic())
-				.title(noticeDto.getTitle())
-				.build();
-			return ResponseEntity.ok(response);
+				// FCM으로 토픽 알림 발송
+				fcmService.sendTopicPush(topicCluster, unreadCountMap);
+			}
+
+			for (PushCluster keywordCluster : keywordClusters) {
+				if (keywordCluster.getTotalCount() > 0) {
+					// 사용자별 읽지 않은 알림 개수 조회
+					Map<Long, Long> keywordUnreadCountMap = pushNotificationService.getUnreadNotificationCountMapForKeyword(keywordCluster.getKeyword().getEncodedKeyword());
+
+					// FCM으로 키워드 알림 발송
+					fcmService.sendKeywordPush(keywordCluster, keywordUnreadCountMap);
+				}
+			}
+
+			return ResponseEntity.ok(WebhookResponse.builder()
+							.result("Webhook processed successfully.")
+							.eventId(clubEvent.getEventId())
+							.topic(noticeDto.getEnglishTopic())
+							.title(noticeDto.getTitle())
+							.build()
+			);
 
 		} catch (CustomException e) {
 			webhookLogger.log("Webhook 처리 중 오류 발생: " + e.getMessage());

--- a/src/main/java/com/example/ajouevent/service/EventCommandService.java
+++ b/src/main/java/com/example/ajouevent/service/EventCommandService.java
@@ -70,7 +70,7 @@ public class EventCommandService {
 
 	// 크롤링한 공지사항 DB에 저장
 	@Transactional
-	public Long postNotice(NoticeDto noticeDto) {
+	public ClubEvent postNotice(NoticeDto noticeDto) {
 		Type type = Type.valueOf(noticeDto.getEnglishTopic().toUpperCase());
 		log.info("저장하는 타입 : " + type.getEnglishTopic());
 
@@ -157,7 +157,7 @@ public class EventCommandService {
 			}
 		}
 
-		return clubEvent.getEventId();
+		return clubEvent;
 	}
 
 	// 게시글 생성 - S3 스프링부트에서 변환

--- a/src/main/java/com/example/ajouevent/service/FCMService.java
+++ b/src/main/java/com/example/ajouevent/service/FCMService.java
@@ -3,14 +3,11 @@ package com.example.ajouevent.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
-import com.example.ajouevent.domain.Keyword;
 import com.example.ajouevent.domain.PushCluster;
 import com.example.ajouevent.domain.PushClusterToken;
-import com.example.ajouevent.dto.UnreadNotificationCountDto;
 import com.example.ajouevent.exception.CustomErrorCode;
 import com.example.ajouevent.exception.CustomException;
 import org.springframework.http.HttpStatus;
@@ -22,7 +19,6 @@ import com.example.ajouevent.domain.Alarm;
 import com.example.ajouevent.domain.AlarmImage;
 import com.example.ajouevent.domain.Member;
 import com.example.ajouevent.domain.Token;
-import com.example.ajouevent.dto.NoticeDto;
 import com.example.ajouevent.dto.ResponseDto;
 import com.example.ajouevent.logger.AlarmLogger;
 import com.example.ajouevent.logger.FcmTokenValidationLogger;
@@ -31,7 +27,6 @@ import com.example.ajouevent.repository.MemberRepository;
 import com.example.ajouevent.repository.PushClusterRepository;
 import com.example.ajouevent.repository.PushClusterTokenBulkRepository;
 import com.example.ajouevent.repository.PushClusterTokenRepository;
-import com.example.ajouevent.repository.PushNotificationRepository;
 import com.example.ajouevent.repository.TokenBulkRepository;
 
 import com.google.api.core.ApiFuture;
@@ -45,6 +40,8 @@ import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -54,13 +51,8 @@ public class FCMService {
 	private final WebhookLogger webhookLogger;
 	private final AlarmLogger alarmLogger;
 	private final FcmTokenValidationLogger fcmTokenValidationLogger;
-
-	private static final String DEFAULT_IMAGE_URL = "https://www.ajou.ac.kr/_res/ajou/kr/img/intro/img-symbol.png";
-	private static final String REDIRECTION_URL_PREFIX = "https://www.ajouevent.com/event/";
-	private static final String DEFAULT_CLICK_ACTION_URL =  "https://www.ajouevent.com";
 	private final PushClusterTokenRepository pushClusterTokenRepository;
 	private final PushClusterTokenBulkRepository pushClusterTokenBulkRepository;
-	private final PushNotificationRepository pushNotificationRepository;
 	private final PushClusterRepository pushClusterRepository;
 	private final TokenBulkRepository tokenBulkRepository;
 
@@ -118,86 +110,6 @@ public class FCMService {
 		);
 	}
 
-	@Transactional
-	public void sendNoticeNotification(NoticeDto noticeDto, Long eventId, Long pushClusterId) {
-		PushCluster pushCluster = pushClusterRepository.findById(pushClusterId)
-			.orElseThrow(() -> new CustomException(CustomErrorCode.PUSH_CLUSTER_NOT_FOUND));
-
-		List<PushClusterToken> clusterTokens = pushClusterTokenRepository.findAllByPushClusterWithTokenAndMember(pushCluster);
-
-		Map<Long, Long> unreadCountMap = pushNotificationRepository.countUnreadNotificationsForTopic(noticeDto.getKoreanTopic())
-			.stream()
-			.collect(Collectors.toMap(UnreadNotificationCountDto::getMemberId, UnreadNotificationCountDto::getUnreadNotificationCount));
-
-		sendPushClusterNotification(
-			clusterTokens,
-			pushCluster,
-			composeMessageTitle(noticeDto),
-			composeBody(noticeDto),
-			getFirstImageUrl(noticeDto),
-			getRedirectionUrl(noticeDto, eventId),
-			unreadCountMap
-		);
-	}
-
-	@Transactional
-	public void sendKeywordPushNotification(List<PushClusterToken> clusterTokens, PushCluster pushCluster, Keyword keyword, NoticeDto noticeDto, Long eventId) {
-		Map<Long, Long> unreadCountMap = pushNotificationRepository.countUnreadNotificationsForKeyword(keyword.getEncodedKeyword())
-			.stream()
-			.collect(Collectors.toMap(UnreadNotificationCountDto::getMemberId, UnreadNotificationCountDto::getUnreadNotificationCount));
-
-		sendPushClusterNotification(
-			clusterTokens,
-			pushCluster,
-			keyword.getKoreanKeyword() + "-" + composeMessageTitle(noticeDto),
-			composeBody(noticeDto),
-			getFirstImageUrl(noticeDto),
-			getRedirectionUrl(noticeDto, eventId),
-			unreadCountMap
-		);
-	}
-
-	public void sendPushClusterNotification(List<PushClusterToken> clusterTokens, PushCluster pushCluster, String title, String body, String imageUrl, String clickUrl, Map<Long, Long> unreadCountMap) {
-		if (clusterTokens.isEmpty()) {
-			webhookLogger.log("푸시 전송 스킵 - PushClusterID: " + pushCluster.getId() + " 알림 대상 토큰이 없습니다.");
-			pushCluster.updateCountsAndStatus(0, 0);  // 대상 없음 처리
-			pushClusterRepository.save(pushCluster);
-			return;
-		}
-
-		pushCluster.markAsInProgress();
-
-		List<List<PushClusterToken>> batches = splitIntoBatches(clusterTokens, 400);
-
-		for (List<PushClusterToken> batch : batches) {
-			batch.forEach(PushClusterToken::markAsSending);  // 각 배치 전송 전 상태 변경
-			pushClusterTokenBulkRepository.saveAll(batch);
-			List<Message> messages = batch.stream()
-				.map(token -> buildMessage(pushCluster.getId(), token, title, body, imageUrl, clickUrl, unreadCountMap))
-				.collect(Collectors.toList());
-
-			ApiFuture<BatchResponse> responseFuture = FirebaseMessaging.getInstance().sendEachAsync(messages);
-
-			responseFuture.addListener(() -> {
-				try {
-					BatchResponse response = responseFuture.get();
-					processPushResult(pushCluster.getId(), batch, response);
-				} catch (InterruptedException e) {
-					Thread.currentThread().interrupt();  // 인터럽트 복구
-					log.warn("FCM 알림 비동기 처리 중 인터럽트 발생", e);
-					batch.forEach(PushClusterToken::markAsFail);
-					updatePushClusterTokens(batch);
-					webhookLogger.log("푸시 전송 중단 (인터럽트): pushClusterId=" + pushCluster.getId());
-				} catch (ExecutionException e) {
-					log.error("FCM 알림 비동기 처리 중 ExecutionException 발생", e);
-					batch.forEach(PushClusterToken::markAsFail);
-					updatePushClusterTokens(batch);
-					webhookLogger.log("푸시 전송 실패 (ExecutionException): pushClusterId=" + pushCluster.getId());
-				}
-			}, Runnable::run);
-		}
-	}
-
 	private Message buildMessage(Long pushClusterId, PushClusterToken token, String title, String body, String imageUrl, String clickUrl, Map<Long, Long> unreadCountMap) {
 		Long unreadCount = unreadCountMap.getOrDefault(token.getToken().getMember().getId(), 0L);
 
@@ -214,7 +126,7 @@ public class FCMService {
 			.build();
 	}
 
-	@Transactional
+	@Transactional(propagation = REQUIRES_NEW)
 	public void processPushResult(Long pushClusterId, List<PushClusterToken> clusterTokens, BatchResponse response) {
 		PushCluster pushCluster = pushClusterRepository.findById(pushClusterId)
 			.orElseThrow(() -> new CustomException(CustomErrorCode.PUSH_CLUSTER_NOT_FOUND));
@@ -245,14 +157,12 @@ public class FCMService {
 
 		pushCluster.updateCountsAndStatus(successCount, failCount);
 		pushClusterRepository.save(pushCluster);
-		webhookLogger.log("푸시 완료 - PushClusterID: " + pushClusterId + " 성공: " + successCount + " 실패: " + failCount);
+		webhookLogger.log("푸시 완료 - PushClusterID: " + pushCluster.getId() + " 성공: " + successCount + " 실패: " + failCount);
 	}
 
 	// pushClusterToken 목록을 일괄 업데이트
 	@Transactional
 	public void updatePushClusterTokens(List<PushClusterToken> clusterTokens) {
-		// ✅ 먼저 저장하여 ID가 생성되도록 함
-		pushClusterTokenRepository.saveAll(clusterTokens);
 		pushClusterTokenBulkRepository.updateAll(clusterTokens);
 	}
 
@@ -279,34 +189,6 @@ public class FCMService {
 			tokensToUpdate.add(token);
 			return false;
 		}
-	}
-
-	private String composeMessageTitle(NoticeDto noticeDto) {
-		return String.format("[%s]", noticeDto.getKoreanTopic());
-	}
-
-	private String composeBody(NoticeDto noticeDto) {
-		return noticeDto.getTitle();
-	}
-
-	private String getFirstImageUrl(NoticeDto noticeDto) {
-		List<String> images = Optional.ofNullable(noticeDto.getImages())
-			.filter(imgs -> !imgs.isEmpty())
-			.orElseGet(() -> {
-				List<String> defaultImages = new ArrayList<>();
-				defaultImages.add(DEFAULT_IMAGE_URL);
-				return defaultImages;
-			});
-		return images.get(0);
-	}
-
-	private String getRedirectionUrl(NoticeDto noticeDto, Long eventId) {
-		String url = Optional.ofNullable(noticeDto.getUrl())
-			.filter(u -> !u.isEmpty())
-			.map(u -> REDIRECTION_URL_PREFIX + eventId) // 크롤링 후 DB에 저장된, 우리 앱 상세페이지로 이동
-			.orElse(DEFAULT_CLICK_ACTION_URL);
-		webhookLogger.log("리다이렉션하는 URL: " + url);
-		return url;
 	}
 
 	public void send(Message message) {
@@ -366,5 +248,62 @@ public class FCMService {
 				invalidTokens.add(token); // 실패한 토큰은 무효로 처리
 			}
 		}
+	}
+
+	public void sendTopicPush(PushCluster cluster, Map<Long, Long> unreadCountMap) {
+		// pushCluster에 연결된 토큰(회원/토큰 정보 포함)을 모두 조회
+		List<PushClusterToken> tokens = pushClusterTokenRepository.findAllByPushClusterWithTokenAndMember(cluster);
+
+		log.info("푸시 전송 대상 토큰 수: {}", tokens.size());
+
+		// 클러스터 상태를 IN_PROGRESS 로 변경 (추후 통계에서 발송 상태 표시)
+		cluster.markAsInProgress();
+
+		// 400개씩 배치로 나누어 전송 (FCM sendEachAsync 권장 범위)
+		List<List<PushClusterToken>> batches = splitIntoBatches(tokens, 400);
+
+		for (List<PushClusterToken> batch : batches) {
+			// 전송 직전 상태를 SENDING 으로 표시
+			batch.forEach(PushClusterToken::markAsSending);  // 각 배치 전송 전 상태 변경
+
+			// 상태값 변경을 일괄 반영
+			pushClusterTokenBulkRepository.updateAll(batch);
+
+			// 실제 FCM 메시지 구성
+			List<Message> messages = batch.stream()
+					.map(token -> buildMessage(cluster.getId(), token, cluster.getTitle(), cluster.getBody(), cluster.getImageUrl(), cluster.getClickUrl(), unreadCountMap))
+					.collect(Collectors.toList());
+
+			// FCM 비동기 발송
+			ApiFuture<BatchResponse> responseFuture = FirebaseMessaging.getInstance().sendEachAsync(messages);
+
+			// 발송 결과를 리스너(콜백)로 처리
+			responseFuture.addListener(() -> {
+				try {
+					BatchResponse response = responseFuture.get();
+					processPushResult(cluster.getId(), batch, response);
+				} catch (InterruptedException e) {
+					// 인터럽트 발생 시 현재 쓰레드 복구
+					Thread.currentThread().interrupt();
+					log.warn("FCM 알림 비동기 처리 중 인터럽트 발생", e);
+
+					// 해당 배치를 모두 실패로 처리
+					batch.forEach(PushClusterToken::markAsFail);
+					updatePushClusterTokens(batch);
+					webhookLogger.log("푸시 전송 중단 (인터럽트): pushClusterId=" + cluster.getId());
+				} catch (ExecutionException e) {
+					log.error("FCM 알림 비동기 처리 중 ExecutionException 발생", e);
+
+					// 해당 배치를 모두 실패로 처리
+					batch.forEach(PushClusterToken::markAsFail);
+					updatePushClusterTokens(batch);
+					webhookLogger.log("푸시 전송 실패 (ExecutionException): pushClusterId=" + cluster.getId());
+				}
+			}, Runnable::run);
+		}
+	}
+
+	public void sendKeywordPush(PushCluster cluster, Map<Long, Long> unreadCountMap) {
+		sendTopicPush(cluster, unreadCountMap);
 	}
 }

--- a/src/main/java/com/example/ajouevent/service/PushClusterService.java
+++ b/src/main/java/com/example/ajouevent/service/PushClusterService.java
@@ -1,12 +1,12 @@
 package com.example.ajouevent.service;
 
-import com.example.ajouevent.domain.PushCluster;
-import com.example.ajouevent.domain.PushNotification;
+import com.example.ajouevent.domain.*;
+import com.example.ajouevent.dto.NoticeDto;
 import com.example.ajouevent.dto.PushClusterStatsResponse;
+import com.example.ajouevent.exception.CustomErrorCode;
+import com.example.ajouevent.exception.CustomException;
 import com.example.ajouevent.logger.PushClusterLogger;
-import com.example.ajouevent.repository.PushClusterBulkRepository;
-import com.example.ajouevent.repository.PushClusterRepository;
-import com.example.ajouevent.repository.PushNotificationRepository;
+import com.example.ajouevent.repository.*;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,8 +26,127 @@ public class PushClusterService {
 	private final PushClusterRepository pushClusterRepository;
 	private final PushClusterBulkRepository pushClusterBulkRepository;
 	private final PushNotificationRepository pushNotificationRepository;
+	private final PushClusterTokenBulkRepository pushClusterTokenBulkRepository;
+	private final TopicRepository topicRepository;
+	private final TopicTokenRepository topicTokenRepository;
+	private final KeywordRepository keywordRepository;
+	private final KeywordTokenRepository keywordTokenRepository;
 	private final RedisService redisService;
 	private final PushClusterLogger pushClusterLogger;
+
+	private static final String DEFAULT_NOTIFICATION_IMAGE_URL = "https://www.ajou.ac.kr/_res/ajou/kr/img/intro/img-symbol.png";
+	private static final String CLICK_URL_PREFIX = "https://www.ajouevent.com/event/";
+	private static final String DEFAULT_CLICK_ACTION_URL =  "https://www.ajouevent.com";
+
+	@Transactional
+	public PushCluster prepareTopicCluster(NoticeDto dto, ClubEvent clubEvent) {
+		// 푸시 알림 메시지 구성
+		String title = composeMessageTitle(dto);
+		String body = composeBody(dto);
+		String imageUrl = getFirstImageUrl(dto);
+		String clickUrl = buildClickUrl(dto, clubEvent.getEventId());
+
+		Topic topic = topicRepository.findByDepartment(dto.getEnglishTopic())
+				.orElseThrow(() -> new CustomException(CustomErrorCode.TOPIC_NOT_FOUND));
+
+		// Topic을 구독 중인 TopicToken 조회 (isDeleted가 false)
+		List<TopicToken> topicTokens = topicTokenRepository.findByTopicWithValidTokensAndReceiveNotificationTrue(topic);
+
+		JobStatus initialStatus = topicTokens.isEmpty() ? JobStatus.NONE : JobStatus.PENDING;
+
+		PushCluster cluster = PushCluster.builder()
+				.clubEvent(clubEvent)
+				.title(title)
+				.body(body)
+				.imageUrl(imageUrl)
+				.clickUrl(clickUrl)
+				.totalCount(topicTokens.size())
+				.jobStatus(initialStatus)
+				.registeredAt(LocalDateTime.now())
+				.topic(topic)
+				.build();
+		pushClusterRepository.save(cluster);
+
+		List<PushClusterToken> clusterTokens = topicTokens.stream()
+				.map(token -> PushClusterToken.builder()
+						.pushCluster(cluster)
+						.token(token.getToken()) // TopicToken에 연결된 Token 가져오기
+						.jobStatus(JobStatus.PENDING) // 초기 상태: PENDING
+						.requestTime(LocalDateTime.now())
+						.build())
+				.toList();
+		pushClusterTokenBulkRepository.saveAll(clusterTokens);
+
+		return cluster;
+	}
+
+	@Transactional
+	public List<PushCluster> prepareKeywordClusters(NoticeDto dto, ClubEvent clubEvent) {
+		List<PushCluster> clusters = new ArrayList<>();
+		Topic topic = topicRepository.findByDepartment(dto.getEnglishTopic())
+				.orElseThrow(() -> new CustomException(CustomErrorCode.TOPIC_NOT_FOUND));
+		List<Keyword> keywords = keywordRepository.findByTopic(topic);
+
+		for (Keyword keyword : keywords) {
+			// 푸시 알림 메시지 구성
+			String title = keyword.getKoreanKeyword() + "-" + composeMessageTitle(dto);
+			String body = composeBody(dto);
+			String imageUrl = getFirstImageUrl(dto);
+			String clickUrl = buildClickUrl(dto, clubEvent.getEventId());
+
+			if (dto.getTitle().contains(keyword.getKoreanKeyword())) {
+				List<KeywordToken> keywordTokens = keywordTokenRepository.findKeywordTokensWithTokenByKeyword(keyword);
+				JobStatus initialStatus = keywordTokens.isEmpty() ? JobStatus.NONE : JobStatus.PENDING;
+				PushCluster cluster = PushCluster.builder()
+						.clubEvent(clubEvent)
+						.topic(topic)
+						.keyword(keyword)
+						.title(title)
+						.body(body)
+						.imageUrl(imageUrl)
+						.clickUrl(clickUrl)
+						.totalCount(keywordTokens.size())
+						.jobStatus(initialStatus)
+						.registeredAt(LocalDateTime.now())
+						.build();
+				pushClusterRepository.save(cluster);
+
+				List<PushClusterToken> clusterTokens = keywordTokens.stream()
+						.map(token -> PushClusterToken.builder()
+								.pushCluster(cluster)
+								.token(token.getToken()) // KeywordToken에 연결된 Token 가져오기
+								.jobStatus(JobStatus.PENDING) // 초기 상태: PENDING
+								.requestTime(LocalDateTime.now())
+								.build())
+						.toList();
+				pushClusterTokenBulkRepository.saveAll(clusterTokens);
+
+				clusters.add(cluster);
+			}
+		}
+		return clusters;
+	}
+
+	private String getFirstImageUrl(NoticeDto dto) {
+		return (dto.getImages() != null && !dto.getImages().isEmpty())
+				? dto.getImages().get(0)
+				: DEFAULT_NOTIFICATION_IMAGE_URL;
+	}
+
+	private String buildClickUrl(NoticeDto noticeDto, Long eventId) {
+        return Optional.ofNullable(noticeDto.getUrl())
+				.filter(u -> !u.isEmpty())
+				.map(u -> CLICK_URL_PREFIX + eventId) // 알림 클릭시, 크롤링 후 DB에 저장된, 앱 상세페이지로 이동
+				.orElse(DEFAULT_CLICK_ACTION_URL);
+	}
+
+	private String composeMessageTitle(NoticeDto noticeDto) {
+		return String.format("[%s]", noticeDto.getKoreanTopic());
+	}
+
+	private String composeBody(NoticeDto noticeDto) {
+		return noticeDto.getTitle();
+	}
 
 	public List<PushClusterStatsResponse> calculateAllPushClusterStats() {
 		List<PushCluster> pushClusters = pushClusterRepository.findAll();

--- a/src/main/java/com/example/ajouevent/service/PushNotificationService.java
+++ b/src/main/java/com/example/ajouevent/service/PushNotificationService.java
@@ -2,50 +2,30 @@ package com.example.ajouevent.service;
 
 import java.security.Principal;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.example.ajouevent.dto.*;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import com.example.ajouevent.domain.ClubEvent;
-import com.example.ajouevent.domain.JobStatus;
-import com.example.ajouevent.domain.Keyword;
 import com.example.ajouevent.domain.KeywordMember;
-import com.example.ajouevent.domain.KeywordToken;
 import com.example.ajouevent.domain.Member;
 import com.example.ajouevent.domain.NotificationType;
 import com.example.ajouevent.domain.PushCluster;
-import com.example.ajouevent.domain.PushClusterToken;
 import com.example.ajouevent.domain.PushNotification;
-import com.example.ajouevent.domain.Topic;
 import com.example.ajouevent.domain.TopicMember;
-import com.example.ajouevent.domain.TopicToken;
-import com.example.ajouevent.dto.KeywordNotificationResponse;
-import com.example.ajouevent.dto.NoticeDto;
-import com.example.ajouevent.dto.NotificationClickRequest;
-import com.example.ajouevent.dto.SliceResponse;
-import com.example.ajouevent.dto.TopicNotificationResponse;
-import com.example.ajouevent.dto.UnreadNotificationCountResponse;
 import com.example.ajouevent.exception.CustomErrorCode;
 import com.example.ajouevent.exception.CustomException;
-import com.example.ajouevent.repository.EventRepository;
 import com.example.ajouevent.repository.KeywordMemberRepository;
-import com.example.ajouevent.repository.KeywordRepository;
-import com.example.ajouevent.repository.KeywordTokenRepository;
 import com.example.ajouevent.repository.MemberRepository;
-import com.example.ajouevent.repository.PushClusterRepository;
-import com.example.ajouevent.repository.PushClusterTokenBulkRepository;
 import com.example.ajouevent.repository.PushNotificationBulkRepository;
 import com.example.ajouevent.repository.PushNotificationRepository;
 import com.example.ajouevent.repository.TopicMemberRepository;
-import com.example.ajouevent.repository.TopicRepository;
-import com.example.ajouevent.repository.TopicTokenRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -56,205 +36,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PushNotificationService {
 
-	private static final String DEFAULT_IMAGE_URL = "https://www.ajou.ac.kr/_res/ajou/kr/img/intro/img-symbol.png";
-	private static final String REDIRECTION_URL_PREFIX = "https://www.ajouevent.com/event/";
-	private static final String DEFAULT_CLICK_ACTION_URL =  "https://www.ajouevent.com";
-
-	private final TopicRepository topicRepository;
 	private final TopicMemberRepository topicMemberRepository;
-	private final PushClusterRepository pushClusterRepository;
 	private final PushNotificationRepository pushNotificationRepository;
-	private final PushClusterTokenBulkRepository pushClusterTokenBulkRepository;
-	private final EventRepository eventRepository;
-	private final TopicTokenRepository topicTokenRepository;
-	private final KeywordTokenRepository keywordTokenRepository;
-	private final KeywordRepository keywordRepository;
 	private final KeywordMemberRepository keywordMemberRepository;
 	private final MemberRepository memberRepository;
-	private final FCMService fcmService;
 	private final PushNotificationBulkRepository pushNotificationBulkRepository;
-
-	@Transactional
-	public Long postPushNotification(NoticeDto noticeDto, Long eventId) {
-
-		// 푸시 알림 메시지 구성
-		String title = composeMessageTitle(noticeDto);
-		String body = composeBody(noticeDto);
-		String imageUrl = getFirstImageUrl(noticeDto);
-		String clickUrl = getRedirectionUrl(noticeDto, eventId);
-
-		// Topic 찾기
-		Topic topic = topicRepository.findByDepartment(noticeDto.getEnglishTopic())
-			.orElseThrow(() -> new CustomException(CustomErrorCode.TOPIC_NOT_FOUND));
-
-		// Topic을 구독 중이고, 알림을 수신 허용한 TopicMember 조회
-		List<TopicMember> topicMembers = topicMemberRepository.findByTopicWithNotificationEnabledAndTokens(topic);
-
-		// Topic을 구독 중인 TopicToken 조회 (isDeleted가 false)
-		List<TopicToken> topicTokens = topicTokenRepository.findByTopicWithValidTokensAndReceiveNotificationTrue(topic);
-
-		// ClubEvent 조회
-		ClubEvent clubEvent = eventRepository.findById(eventId)
-			.orElseThrow(() -> new CustomException(CustomErrorCode.EVENT_NOT_FOUND));
-
-		// PushCluster 생성
-		PushCluster pushCluster = PushCluster.builder()
-			.clubEvent(clubEvent)
-			.title(title)
-			.body(body)
-			.imageUrl(imageUrl)
-			.clickUrl(clickUrl)
-			.totalCount(topicTokens.size())
-			.registeredAt(LocalDateTime.now())
-			.jobStatus(JobStatus.PENDING)
-			.build();
-		pushClusterRepository.save(pushCluster);
-
-		// 이 시점에서 pushCluster.getId()를 바로 사용할 수 있음
-		Long pushClusterId = pushCluster.getId();
-		log.info("토픽에서 - Generated PushCluster ID: {}", pushClusterId);
-
-		// PushClusterTokens 생성
-		List<PushClusterToken> clusterTokens = topicTokens.stream()
-			.map(token -> PushClusterToken.builder()
-				.pushCluster(pushCluster)
-				.token(token.getToken()) // TopicToken에 연결된 Token 가져오기
-				.jobStatus(JobStatus.PENDING) // 초기 상태: PENDING
-				.requestTime(LocalDateTime.now()) // 요청 시간 기록
-				.build())
-			.collect(Collectors.toList());
-		pushClusterTokenBulkRepository.saveAll(clusterTokens);
-
-		// PushNotifications 생성
-		List<PushNotification> notifications = topicMembers.stream()
-			.map(member -> PushNotification.builder()
-				.pushCluster(pushCluster)
-				.member(member.getMember())
-				.topic(topic)
-				.title(title)
-				.body(body)
-				.imageUrl(imageUrl)
-				.clickUrl(clickUrl)
-				.notificationType(NotificationType.TOPIC)
-				.notifiedAt(LocalDateTime.now())
-				.build())
-			.collect(Collectors.toList());
-		pushNotificationBulkRepository.saveAll(notifications);
-
-		return pushCluster.getId(); // PushCluster ID 반환
-	}
-
-	private String composeMessageTitle(NoticeDto noticeDto) {
-		return String.format("[%s]", noticeDto.getKoreanTopic());
-	}
-
-	private String composeBody(NoticeDto noticeDto) {
-		return noticeDto.getTitle();
-	}
-
-	private String getFirstImageUrl(NoticeDto noticeDto) {
-		List<String> images = Optional.ofNullable(noticeDto.getImages())
-			.filter(imgs -> !imgs.isEmpty())
-			.orElseGet(() -> {
-				List<String> defaultImages = new ArrayList<>();
-				defaultImages.add(DEFAULT_IMAGE_URL);
-				return defaultImages;
-			});
-		return images.get(0);
-	}
-
-	private String getRedirectionUrl(NoticeDto noticeDto, Long eventId) {
-		String url = Optional.ofNullable(noticeDto.getUrl())
-			.filter(u -> !u.isEmpty())
-			.map(u -> REDIRECTION_URL_PREFIX + eventId) // 크롤링 후 DB에 저장된, 우리 앱 상세페이지로 이동
-			.orElse(DEFAULT_CLICK_ACTION_URL);
-		log.info("리다이렉션하는 URL: {}", url);
-		return url;
-	}
-
-	@Transactional
-	public void handleKeywordPushNotification(NoticeDto noticeDto, Long eventId) {
-
-		// Topic 찾기
-		Topic topic = topicRepository.findByDepartment(noticeDto.getEnglishTopic())
-			.orElseThrow(() -> new CustomException(CustomErrorCode.TOPIC_NOT_FOUND));
-
-		// 해당 Topic에 설정된 모든 Keyword 가져오기
-		List<Keyword> keywords = keywordRepository.findByTopic(topic);
-
-		// 크롤링된 제목에서 키워드 매칭
-		List<Keyword> matchedKeywords = keywords.stream()
-			.filter(keyword -> noticeDto.getTitle().contains(keyword.getKoreanKeyword()))
-			.collect(Collectors.toList());
-
-		if (matchedKeywords.isEmpty()) {
-			log.info("매칭된 키워드가 없습니다. 푸시 알림을 발송하지 않습니다.");
-			return;
-		}
-
-		// ClubEvent 조회
-		ClubEvent clubEvent = eventRepository.findById(eventId)
-			.orElseThrow(() -> new CustomException(CustomErrorCode.EVENT_NOT_FOUND));
-
-		for (Keyword keyword : matchedKeywords) {
-			String title = keyword.getKoreanKeyword() + "-" + composeMessageTitle(noticeDto);
-			String body = composeBody(noticeDto);
-			String imageUrl = getFirstImageUrl(noticeDto);
-			String clickUrl = getRedirectionUrl(noticeDto, eventId);
-
-			// 해당 키워드에 구독된 사용자 조회
-			List<KeywordMember> keywordMembers = keywordMemberRepository.findByKeyword(keyword);
-			List<KeywordToken> keywordTokens = keywordTokenRepository.findKeywordTokensWithTokenByKeyword(keyword);
-
-			// PushCluster 생성
-			PushCluster pushCluster = PushCluster.builder()
-				.clubEvent(clubEvent)
-				.title(title)
-				.body(body)
-				.imageUrl(imageUrl)
-				.clickUrl(clickUrl)
-				.totalCount(keywordTokens.size())
-				.registeredAt(LocalDateTime.now())
-				.jobStatus(JobStatus.PENDING)
-				.build();
-			pushClusterRepository.save(pushCluster);
-
-			// 이 시점에서 pushCluster.getId()를 바로 사용할 수 있음
-			Long pushClusterId = pushCluster.getId();
-			log.info("키워드에서 - Generated PushCluster ID: {}", pushClusterId);
-
-			// PushClusterToken 생성
-			List<PushClusterToken> clusterTokens = keywordTokens.stream()
-				.map(token -> PushClusterToken.builder()
-					.pushCluster(pushCluster)
-					.token(token.getToken())
-					.jobStatus(JobStatus.PENDING)
-					.requestTime(LocalDateTime.now())
-					.build())
-				.collect(Collectors.toList());
-
-			// PushNotification 생성
-			List<PushNotification> notifications = keywordMembers.stream()
-				.map(member -> PushNotification.builder()
-					.pushCluster(pushCluster)
-					.member(member.getMember())
-					.keyword(keyword)
-					.title(title)
-					.body(body)
-					.imageUrl(imageUrl)
-					.topic(topic)
-					.clickUrl(clickUrl)
-					.notificationType(NotificationType.KEYWORD)
-					.notifiedAt(LocalDateTime.now())
-					.build())
-				.collect(Collectors.toList());
-			pushNotificationBulkRepository.saveAll(notifications);
-
-			// FCM 푸시 알림 전송
-			fcmService.sendKeywordPushNotification(clusterTokens, pushCluster, keyword, noticeDto, eventId);
-
-		}
-	}
 
 	// Topic 알림 조회
 	@Transactional
@@ -375,6 +161,69 @@ public class PushNotificationService {
 		}
 
 		pushNotificationBulkRepository.updateReadStatus(notifications);
+	}
+
+	@Transactional
+	public void saveTopicNotifications(PushCluster cluster) {
+		// Topic을 구독 중이고, 알림을 수신 허용한 TopicMember 조회
+		List<TopicMember> topicMembers = topicMemberRepository.findByTopicWithNotificationEnabledAndTokens(cluster.getTopic());
+
+		List<PushNotification> notifications = topicMembers.stream()
+				.map(member -> PushNotification.builder()
+						.pushCluster(cluster)
+						.member(member.getMember())
+						.topic(cluster.getTopic())
+						.title(cluster.getTitle())
+						.body(cluster.getBody())
+						.imageUrl(cluster.getImageUrl())
+						.clickUrl(cluster.getClickUrl())
+						.notificationType(NotificationType.TOPIC)
+						.notifiedAt(LocalDateTime.now())
+						.build())
+				.toList();
+		pushNotificationBulkRepository.saveAll(notifications);
+	}
+
+	@Transactional
+	public void saveKeywordNotifications(List<PushCluster> clusters) {
+		for (PushCluster cluster : clusters) {
+			List<KeywordMember> keywordMembers = keywordMemberRepository.findByKeyword(cluster.getKeyword());
+			List<PushNotification> notifications = keywordMembers.stream()
+					.map(member -> PushNotification.builder()
+							.pushCluster(cluster)
+							.member(member.getMember())
+							.keyword(cluster.getKeyword())
+							.topic(cluster.getTopic())
+							.title(cluster.getTitle())
+							.body(cluster.getBody())
+							.imageUrl(cluster.getImageUrl())
+							.clickUrl(cluster.getClickUrl())
+							.notificationType(NotificationType.KEYWORD)
+							.notifiedAt(LocalDateTime.now())
+							.build())
+					.toList();
+			pushNotificationBulkRepository.saveAll(notifications);
+		}
+	}
+
+	@Transactional
+	public Map<Long, Long> getUnreadNotificationCountMapForTopic(String koreanTopic) {
+		return pushNotificationRepository.countUnreadNotificationsForTopic(koreanTopic)
+				.stream()
+				.collect(Collectors.toMap(
+                        UnreadNotificationCountDto::getMemberId,
+                        UnreadNotificationCountDto::getUnreadNotificationCount
+				));
+	}
+
+	@Transactional
+	public Map<Long, Long> getUnreadNotificationCountMapForKeyword(String encodedKeyword) {
+		return pushNotificationRepository.countUnreadNotificationsForKeyword(encodedKeyword)
+				.stream()
+				.collect(Collectors.toMap(
+                        UnreadNotificationCountDto::getMemberId,
+                        UnreadNotificationCountDto::getUnreadNotificationCount
+				));
 	}
 
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈

> #103 

## 💻 작업 내용
- [x] Topic/Keyword으로 PushCluster 생성, 푸시 알림 저장 및 발송 책임 분리
- [x] FCM 외부 API 호출 고려하여 트랜잭션 범위 최소화
- [x] PushCluster에 Topic/Keyword 연관 필드 추가

## 💬 리뷰 요구사항 

> 리뷰 시 중점적으로 확인해 주셨으면 하는 부분입니다.

현재 WebhookFacade에서 발송 대상 토큰 수가 0개일 경우, FCM 발송을 생략하도록 처리했습니다.
그리고 사용자별 읽지 않은 알림 개수를 조회해 FCM 메시지에 포함시키는 로직도 WebhookFacade에서 수행하고 있습니다.

다만, 다음과 같은 구조도 고려하고 있어 고민 중입니다:
	1. 현재 방식 (PR 내용)
	- WebhookFacade에서 → 토큰 수 확인 → 사용자별 unread count 조회 → FCMService 호출
	2. 대안 방식
	- FCMService 내부에서 → 토큰 수 확인 및 사용자별 unread count 조회 → 푸시 발송 처리

## 🔍 추후 고려사항
FCM 메시지를 400개 단위로 배치 처리하며, 각 배치는 비동기적으로 전송되고, 콜백 스레드풀을 통해 응답을 개별적으로 처리합니다.

이 과정에서 PushCluster의 성공/실패 카운트, 최종 상태(jobStatus), 종료 시간(endAt)을 각 배치 단위로 갱신하고 있는데, 동시성 이슈가 발생할 가능성이 있습니다.
	- PushCluster와 매핑된 PushClusterToken에 성공/실패 여부가 별도로 기록되기 때문에, 관리자 페이지에서는 이를 기준으로 PushCluster의 successCount, failCount, 성공/실패/일부 실패 여부를 유추할 수 있습니다.
	- 그러나 PushCluster 자체의 집계 정보(ex. 발송 작업 끝나는 시간 - endAt)는 여러 스레드에서 동시에 갱신될 수 있어 충돌 가능성이 존재합니다.
이 부분에 대해 의견이나 더 나은 구조에 대한 제안이 있다면 공유 부탁드립니다.