### PR TITLE
[Refactor] 엔티티 정적 팩토리 메서드 패턴 적용 및 생성자 접근 제어 리팩토링 refactor 코드 리팩토링

### DIFF
--- a/src/main/java/com/example/ajouevent/domain/Banner.java
+++ b/src/main/java/com/example/ajouevent/domain/Banner.java
@@ -1,18 +1,15 @@
 package com.example.ajouevent.domain;
 
-
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
 
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Banner {
+@Table(name = "banner")
+public class Banner extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long bannerId;
@@ -31,5 +28,25 @@ public class Banner {
 
 	@Column(nullable = false)
 	private LocalDate endDate;
+
+	@Builder
+	private Banner(String imgUrl, String siteUrl, Long bannerOrder, LocalDate startDate, LocalDate endDate) {
+		this.imgUrl = imgUrl;
+		this.siteUrl = siteUrl;
+		this.bannerOrder = bannerOrder;
+		this.startDate = startDate;
+		this.endDate = endDate;
+	}
+
+	public static Banner create(String imgUrl, String siteUrl, Long bannerOrder, LocalDate startDate,
+		LocalDate endDate) {
+		return Banner.builder()
+			.imgUrl(imgUrl)
+			.siteUrl(siteUrl)
+			.bannerOrder(bannerOrder)
+			.startDate(startDate)
+			.endDate(endDate)
+			.build();
+	}
 
 }

--- a/src/main/java/com/example/ajouevent/domain/BaseTimeEntity.java
+++ b/src/main/java/com/example/ajouevent/domain/BaseTimeEntity.java
@@ -1,0 +1,32 @@
+package com.example.ajouevent.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	private LocalDateTime modifiedAt;
+
+	public LocalDateTime getDate() {
+		LocalDateTime time = this.createdAt;
+		if (modifiedAt != null) {
+			time = this.modifiedAt;
+		}
+		return time;
+	}
+}

--- a/src/main/java/com/example/ajouevent/domain/ClubEvent.java
+++ b/src/main/java/com/example/ajouevent/domain/ClubEvent.java
@@ -4,93 +4,128 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.annotations.BatchSize;
 
 import com.example.ajouevent.dto.UpdateEventRequest;
 
-@Entity
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class ClubEvent {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long eventId;
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "club_event")
+public class ClubEvent extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long eventId;
 
-    @Column
-    private String title;
+	@Column
+	private String title;
 
-    @Column(length = 50000)
-    private String content;
+	@Column(length = 50000)
+	private String content;
 
-    @Column // 게시글 작성자(작성 기관)
-    private String writer;
+	@Column // 게시글 작성자(작성 기관)
+	private String writer;
 
-    @Column // 게시글 생성 시간
-    private LocalDateTime createdAt;
+	@Column // 게시글 생성 시간
+	private LocalDateTime createdAt;
 
-    @Column // 게시글 분류(topic) - 아주대학교 - 일반, 소프트웨어학과, 동아리
-    private String subject;
+	@Column // 게시글 분류(topic) - 아주대학교 - 일반, 소프트웨어학과, 동아리
+	private String subject;
 
-    @Column // 원래 공지사항 url
-    private String url;
+	@Column // 원래 공지사항 url
+	private String url;
 
-    @Column // 찜한 수 (default는 0)
-    private Long likesCount;
+	@Column // 찜한 수 (default는 0)
+	private Long likesCount;
 
-    @Column // 조회 수 (default는 0)
-    private Long viewCount;
+	@Column // 조회 수 (default는 0)
+	private Long viewCount;
 
-    @Column(length = 50000)
-    @Enumerated(value = EnumType.STRING)
-    private Type type;
+	@Column(length = 50000)
+	@Enumerated(value = EnumType.STRING)
+	private Type type;
 
-    @BatchSize(size=100) //
-    @OneToMany(mappedBy = "clubEvent", fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
-    @ToString.Exclude
-    private List<ClubEventImage> clubEventImageList;
+	@BatchSize(size = 100)
+	@OneToMany(mappedBy = "clubEvent", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+	@ToString.Exclude
+	private List<ClubEventImage> clubEventImageList;
 
-    public void updateEvent(UpdateEventRequest request) {
-        if (request.getTitle() != null) {
-            this.title = request.getTitle();
-        }
-        if (request.getContent() != null) {
-            this.content = request.getContent();
-        }
-        if (request.getWriter() != null) {
-            this.writer = request.getWriter();
-        }
-        if (request.getSubject() != null) {
-            this.subject = request.getSubject();
-        }
-        if (request.getUrl() != null) {
-            this.url = request.getUrl();
-        }
-        if (request.getType() != null) {
-            this.type = request.getType();
-        }
-        // date는 일반적으로 업데이트 요청 시 현재 시간으로 설정하는 것이 일반적이므로 주석 처리
-        this.createdAt = LocalDateTime.now();
-    }
+	@Builder
+	private ClubEvent(String title, String content, String writer, LocalDateTime createdAt,
+		String subject, String url, Long likesCount, Long viewCount, Type type,
+		List<ClubEventImage> clubEventImageList) {
+		this.title = title;
+		this.content = content;
+		this.writer = writer;
+		this.createdAt = createdAt;
+		this.subject = subject;
+		this.url = url;
+		this.likesCount = likesCount;
+		this.viewCount = viewCount;
+		this.type = type;
+		this.clubEventImageList = clubEventImageList;
+	}
 
-    // 게시글의 저장수 증가
-    public void incrementLikes() {
-        this.likesCount++;
-    }
+	public static ClubEvent create(String title, String content, String writer,
+		LocalDateTime createdAt, String subject, String url,
+		Type type, Long likesCount, Long viewCount) {
+		return ClubEvent.builder()
+			.title(title)
+			.content(content)
+			.writer(writer)
+			.createdAt(createdAt)
+			.subject(subject)
+			.url(url)
+			.type(type)
+			.likesCount(likesCount)
+			.viewCount(viewCount)
+			.clubEventImageList(new ArrayList<>()) // 기본 초기화
+			.build();
+	}
 
-    // 게시글의 저장수 감소
-    public void decreaseLikes() {
-        this.likesCount--;
-    }
+	public void assignImages(List<ClubEventImage> images) {
+		this.clubEventImageList = new ArrayList<>(images);
+	}
 
-    // // 게시글의 조회수 증가
-    // public void increaseViewCount() {
-    //     this.viewCount++; // 조회수 증가
-    // }
+	public void updateEvent(UpdateEventRequest request) {
+		if (request.getTitle() != null) {
+			this.title = request.getTitle();
+		}
+		if (request.getContent() != null) {
+			this.content = request.getContent();
+		}
+		if (request.getWriter() != null) {
+			this.writer = request.getWriter();
+		}
+		if (request.getSubject() != null) {
+			this.subject = request.getSubject();
+		}
+		if (request.getUrl() != null) {
+			this.url = request.getUrl();
+		}
+		if (request.getType() != null) {
+			this.type = request.getType();
+		}
+		// date는 일반적으로 업데이트 요청 시 현재 시간으로 설정하는 것이 일반적이므로 주석 처리
+		this.createdAt = LocalDateTime.now();
+	}
 
+	// 게시글의 저장수 증가
+	public void incrementLikes() {
+		this.likesCount++;
+	}
+
+	// 게시글의 저장수 감소
+	public void decreaseLikes() {
+		this.likesCount--;
+	}
+
+	// // 게시글의 조회수 증가
+	// public void increaseViewCount() {
+	//     this.viewCount++; // 조회수 증가
+	// }
 
 }

--- a/src/main/java/com/example/ajouevent/domain/ClubEventImage.java
+++ b/src/main/java/com/example/ajouevent/domain/ClubEventImage.java
@@ -3,12 +3,10 @@ package com.example.ajouevent.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Entity
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "club_event_image")
 public class ClubEventImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,4 +19,17 @@ public class ClubEventImage {
     @JoinColumn (name = "club_event_id")
     @ToString.Exclude
     private ClubEvent clubEvent;
+
+    @Builder
+    private ClubEventImage(String url, ClubEvent clubEvent) {
+        this.url = url;
+        this.clubEvent = clubEvent;
+    }
+
+    public static ClubEventImage create(String url, ClubEvent clubEvent) {
+        return ClubEventImage.builder()
+            .url(url)
+            .clubEvent(clubEvent)
+            .build();
+    }
 }

--- a/src/main/java/com/example/ajouevent/domain/EventLike.java
+++ b/src/main/java/com/example/ajouevent/domain/EventLike.java
@@ -1,8 +1,5 @@
 package com.example.ajouevent.domain;
 
-import com.google.firebase.database.annotations.NotNull;
-
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -11,21 +8,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
-@Entity
-@Setter
+
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 @Table(name = "event_like_table")
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class EventLike {
+public class EventLike extends BaseTimeEntity {
 
 	@Id // pk 지정
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,5 +32,18 @@ public class EventLike {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
+
+	@Builder
+	private EventLike(ClubEvent clubEvent, Member member) {
+		this.clubEvent = clubEvent;
+		this.member = member;
+	}
+
+	public static EventLike create(ClubEvent clubEvent, Member member) {
+		return EventLike.builder()
+			.clubEvent(clubEvent)
+			.member(member)
+			.build();
+	}
 
 }

--- a/src/main/java/com/example/ajouevent/domain/Keyword.java
+++ b/src/main/java/com/example/ajouevent/domain/Keyword.java
@@ -8,17 +8,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class Keyword {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "keyword")
+public class Keyword extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -29,9 +30,27 @@ public class Keyword {
 	@Column
 	private String koreanKeyword;
 
-	@Column String searchKeyword;
+	@Column
+	String searchKeyword;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "topic_id")
 	private Topic topic;
+
+	@Builder
+	private Keyword(String encodedKeyword, String koreanKeyword, String searchKeyword, Topic topic) {
+		this.encodedKeyword = encodedKeyword;
+		this.koreanKeyword = koreanKeyword;
+		this.searchKeyword = searchKeyword;
+		this.topic = topic;
+	}
+
+	public static Keyword create(String encodedKeyword, String koreanKeyword, String searchKeyword, Topic topic) {
+		return Keyword.builder()
+			.encodedKeyword(encodedKeyword)
+			.koreanKeyword(koreanKeyword)
+			.searchKeyword(searchKeyword)
+			.topic(topic)
+			.build();
+	}
 }

--- a/src/main/java/com/example/ajouevent/domain/KeywordMember.java
+++ b/src/main/java/com/example/ajouevent/domain/KeywordMember.java
@@ -10,19 +10,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Entity
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class KeywordMember {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "keyword_member")
+public class KeywordMember extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -40,4 +39,31 @@ public class KeywordMember {
 
 	@Column(nullable = false)
 	private LocalDateTime lastReadAt;  // 마지막으로 읽은 시각
+
+	@Builder
+	private KeywordMember(Keyword keyword, Member member, boolean isRead, LocalDateTime lastReadAt) {
+		this.keyword = keyword;
+		this.member = member;
+		this.isRead = isRead;
+		this.lastReadAt = lastReadAt;
+	}
+
+	public static KeywordMember create(Keyword keyword, Member member) {
+		return KeywordMember.builder()
+			.keyword(keyword)
+			.member(member)
+			.isRead(false) // 구독 후, 기본 읽음 상태는 false
+			.lastReadAt(LocalDateTime.now())
+			.build();
+	}
+
+	public void markAsRead() {
+		this.isRead = true;
+		this.lastReadAt = LocalDateTime.now();
+	}
+
+	public void markAsUnread() {
+		this.isRead = false;
+		this.lastReadAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/example/ajouevent/domain/KeywordToken.java
+++ b/src/main/java/com/example/ajouevent/domain/KeywordToken.java
@@ -7,17 +7,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class KeywordToken {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "keyword_token")
+public class KeywordToken extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -30,8 +31,16 @@ public class KeywordToken {
 	@JoinColumn(name = "token_id")
 	private Token token;
 
-	public KeywordToken(Keyword keyword, Token token) {
+	@Builder
+	private KeywordToken(Keyword keyword, Token token) {
 		this.keyword = keyword;
 		this.token = token;
+	}
+
+	public static KeywordToken create(Keyword keyword, Token token) {
+		return KeywordToken.builder()
+			.keyword(keyword)
+			.token(token)
+			.build();
 	}
 }

--- a/src/main/java/com/example/ajouevent/domain/Member.java
+++ b/src/main/java/com/example/ajouevent/domain/Member.java
@@ -6,10 +6,10 @@ import lombok.*;
 import java.util.List;
 
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Member {
+@Table(name = "member")
+public class Member extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(nullable = false, unique = true)
@@ -55,12 +55,30 @@ public class Member {
 	private List<KeywordMember> keywordMembers;
 
 	@Builder
-	public Member(Long id, String email, String name, String password, String major, String phone) {
+	private Member(Long id, String email, String name) {
 		this.id = id;
 		this.email = email;
 		this.name = name;
-		this.password = password;
-		this.major = major;
-		this.phone = phone;
+	}
+
+	public static Member register(String email, String name) {
+		return Member.builder()
+			.email(email)
+			.name(name)
+			.build();
+	}
+
+	public void changePassword(String encodedPassword) {
+		this.password = encodedPassword;
+	}
+
+	public void changeMajor(String major) {
+		if (major != null) this.major = major;
+	}
+
+	public void updateProfile(String name, String major, String phone) {
+		if (name != null) this.name = name;
+		if (major != null) this.major = major;
+		if (phone != null) this.phone = phone;
 	}
 }

--- a/src/main/java/com/example/ajouevent/domain/PushCluster.java
+++ b/src/main/java/com/example/ajouevent/domain/PushCluster.java
@@ -16,25 +16,24 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Entity
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class PushCluster {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "push_cluster")
+public class PushCluster extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "club_event_id", nullable = true) // 연관된 이벤트
+	@JoinColumn(name = "club_event_id") // 연관된 이벤트
 	private ClubEvent clubEvent;
 
 	@Column(nullable = false)
@@ -88,6 +87,76 @@ public class PushCluster {
 	@JoinColumn(name = "keyword_id")
 	private Keyword keyword;
 
+	@Builder
+	private PushCluster(ClubEvent clubEvent, String title, String body, String imageUrl, String clickUrl,
+		JobStatus jobStatus, int totalCount, LocalDateTime registeredAt, int successCount, int failCount,
+		int receivedCount, int clickedCount, LocalDateTime startAt, LocalDateTime endAt,
+		Topic topic, Keyword keyword) {
+		this.clubEvent = clubEvent;
+		this.title = title;
+		this.body = body;
+		this.imageUrl = imageUrl;
+		this.clickUrl = clickUrl;
+		this.jobStatus = jobStatus;
+		this.totalCount = totalCount;
+		this.registeredAt = registeredAt;
+		this.successCount = successCount;
+		this.failCount = failCount;
+		this.receivedCount = receivedCount;
+		this.clickedCount = clickedCount;
+		this.startAt = startAt;
+		this.endAt = endAt;
+		this.topic = topic;
+		this.keyword = keyword;
+	}
+
+	// Topic 기반 푸시 클러스터 생성
+	public static PushCluster createForTopic(ClubEvent clubEvent, Topic topic,
+		String title, String body, String imageUrl, String clickUrl,
+		int totalCount, JobStatus jobStatus) {
+		return PushCluster.builder()
+			.clubEvent(clubEvent)
+			.topic(topic)
+			.title(title)
+			.body(body)
+			.imageUrl(imageUrl)
+			.clickUrl(clickUrl)
+			.totalCount(totalCount)
+			.jobStatus(jobStatus)
+			.registeredAt(LocalDateTime.now())
+			.startAt(LocalDateTime.now())
+			.endAt(LocalDateTime.now())
+			.successCount(0)
+			.failCount(0)
+			.receivedCount(0)
+			.clickedCount(0)
+			.build();
+	}
+
+	// Keyword 기반 푸시 클러스터 생성
+	public static PushCluster createForKeyword(ClubEvent clubEvent, Topic topic, Keyword keyword,
+		String title, String body, String imageUrl, String clickUrl,
+		int totalCount, JobStatus jobStatus) {
+		return PushCluster.builder()
+			.clubEvent(clubEvent)
+			.topic(topic)
+			.keyword(keyword)
+			.title(title)
+			.body(body)
+			.imageUrl(imageUrl)
+			.clickUrl(clickUrl)
+			.totalCount(totalCount)
+			.jobStatus(jobStatus)
+			.registeredAt(LocalDateTime.now())
+			.startAt(LocalDateTime.now())
+			.endAt(LocalDateTime.now())
+			.successCount(0)
+			.failCount(0)
+			.receivedCount(0)
+			.clickedCount(0)
+			.build();
+	}
+
 	// 작업 시작 기록
 	public void markAsInProgress() {
 		this.startAt = LocalDateTime.now();
@@ -107,5 +176,13 @@ public class PushCluster {
 		}
 
 		this.endAt = LocalDateTime.now();
+	}
+
+	public void addReceivedCount(int count) {
+		this.receivedCount += count;
+	}
+
+	public void addClickedCount(int count) {
+		this.clickedCount += count;
 	}
 }

--- a/src/main/java/com/example/ajouevent/domain/PushClusterToken.java
+++ b/src/main/java/com/example/ajouevent/domain/PushClusterToken.java
@@ -12,19 +12,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Entity
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class PushClusterToken {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "push_cluster_token")
+public class PushClusterToken extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -46,6 +45,25 @@ public class PushClusterToken {
 
 	@Column(nullable = true)
 	private LocalDateTime processedTime; // 발송 처리 시간
+
+	@Builder
+	private PushClusterToken(PushCluster pushCluster, Token token, JobStatus jobStatus,
+		LocalDateTime requestTime, LocalDateTime processedTime) {
+		this.pushCluster = pushCluster;
+		this.token = token;
+		this.jobStatus = jobStatus;
+		this.requestTime = requestTime;
+		this.processedTime = processedTime;
+	}
+
+	public static PushClusterToken create(PushCluster cluster, Token token) {
+		return PushClusterToken.builder()
+			.pushCluster(cluster)
+			.token(token)
+			.jobStatus(JobStatus.PENDING) // 초기 상태
+			.requestTime(LocalDateTime.now())
+			.build();
+	}
 
 	public void markAsSending() {
 		this.jobStatus = JobStatus.IN_PROGRESS;

--- a/src/main/java/com/example/ajouevent/domain/PushNotification.java
+++ b/src/main/java/com/example/ajouevent/domain/PushNotification.java
@@ -12,19 +12,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Entity
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class PushNotification {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "push_notification")
+public class PushNotification extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -69,6 +68,52 @@ public class PushNotification {
 
 	@Column(nullable = true)
 	private LocalDateTime notifiedAt; // 알림 전달 시간
+
+	@Builder
+	private PushNotification(PushCluster pushCluster, Topic topic, Keyword keyword, Member member,
+		NotificationType notificationType, String title, String body,
+		String imageUrl, String clickUrl, LocalDateTime notifiedAt) {
+		this.pushCluster = pushCluster;
+		this.topic = topic;
+		this.keyword = keyword;
+		this.member = member;
+		this.notificationType = notificationType;
+		this.title = title;
+		this.body = body;
+		this.imageUrl = imageUrl;
+		this.clickUrl = clickUrl;
+		this.isRead = false;
+		this.notifiedAt = notifiedAt;
+	}
+
+	public static PushNotification createForTopic(PushCluster cluster, Member member) {
+		return PushNotification.builder()
+			.pushCluster(cluster)
+			.member(member)
+			.topic(cluster.getTopic())
+			.title(cluster.getTitle())
+			.body(cluster.getBody())
+			.imageUrl(cluster.getImageUrl())
+			.clickUrl(cluster.getClickUrl())
+			.notificationType(NotificationType.TOPIC)
+			.notifiedAt(LocalDateTime.now())
+			.build();
+	}
+
+	public static PushNotification createForKeyword(PushCluster cluster, Member member) {
+		return PushNotification.builder()
+			.pushCluster(cluster)
+			.member(member)
+			.keyword(cluster.getKeyword())
+			.topic(cluster.getTopic())
+			.title(cluster.getTitle())
+			.body(cluster.getBody())
+			.imageUrl(cluster.getImageUrl())
+			.clickUrl(cluster.getClickUrl())
+			.notificationType(NotificationType.KEYWORD)
+			.notifiedAt(LocalDateTime.now())
+			.build();
+	}
 
 	public void markAsRead() {
 		this.isRead = true;

--- a/src/main/java/com/example/ajouevent/domain/Token.java
+++ b/src/main/java/com/example/ajouevent/domain/Token.java
@@ -12,19 +12,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Entity
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class Token {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "token")
+public class Token extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -45,7 +44,28 @@ public class Token {
 	@Column(nullable = false)
 	private boolean isDeleted = false;
 
+	@Builder
+	private Token(String tokenValue, LocalDate expirationDate, boolean isDeleted, Member member) {
+		this.tokenValue = tokenValue;
+		this.expirationDate = expirationDate;
+		this.isDeleted = isDeleted;
+		this.member = member;
+	}
+
+	public static Token create(String tokenValue, Member member, int validWeeks) {
+		return Token.builder()
+			.tokenValue(tokenValue)
+			.member(member)
+			.expirationDate(LocalDate.now().plusWeeks(validWeeks))
+			.isDeleted(false)
+			.build();
+	}
+
 	public void markAsDeleted() {
 		this.isDeleted = true;
+	}
+
+	public void extendExpiration(int weeks) {
+		this.expirationDate = LocalDate.now().plusWeeks(weeks);
 	}
 }

--- a/src/main/java/com/example/ajouevent/domain/Topic.java
+++ b/src/main/java/com/example/ajouevent/domain/Topic.java
@@ -10,16 +10,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "topic")
 public class Topic {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/ajouevent/domain/TopicMember.java
+++ b/src/main/java/com/example/ajouevent/domain/TopicMember.java
@@ -2,27 +2,14 @@ package com.example.ajouevent.domain;
 
 import java.time.LocalDateTime;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import jakarta.persistence.*;
+import lombok.*;
 
-@Entity
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class TopicMember {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "topic_member")
+public class TopicMember extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -43,4 +30,41 @@ public class TopicMember {
 
 	@Column(nullable = false, columnDefinition = "TINYINT(1)")
 	private boolean receiveNotification;
+
+	@Builder
+	private TopicMember(Member member, Topic topic, boolean isRead,
+		LocalDateTime lastReadAt, boolean receiveNotification) {
+		this.member = member;
+		this.topic = topic;
+		this.isRead = isRead;
+		this.lastReadAt = lastReadAt;
+		this.receiveNotification = receiveNotification;
+	}
+
+	public static TopicMember create(Member member, Topic topic) {
+		return TopicMember.builder()
+			.member(member)
+			.topic(topic)
+			.isRead(false)
+			.lastReadAt(LocalDateTime.now())
+			.receiveNotification(true)
+			.build();
+	}
+
+	/** 알림을 읽지 않은 상태로 변경 */
+	public void markAsUnread() {
+		this.isRead = false;
+		this.lastReadAt = LocalDateTime.now();
+	}
+
+	/** 알림을 읽은 상태로 변경 */
+	public void markAsRead() {
+		this.isRead = true;
+		this.lastReadAt = LocalDateTime.now();
+	}
+
+	/** 알림 수신 여부 변경 */
+	public void changeReceiveNotification(boolean value) {
+		this.receiveNotification = value;
+	}
 }

--- a/src/main/java/com/example/ajouevent/domain/TopicToken.java
+++ b/src/main/java/com/example/ajouevent/domain/TopicToken.java
@@ -7,17 +7,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class TopicToken {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "topic_token")
+public class TopicToken extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -30,8 +31,16 @@ public class TopicToken {
 	@JoinColumn(name = "token_id")
 	private Token token;
 
-	public TopicToken(Topic topic, Token token) {
+	@Builder
+	private TopicToken(Topic topic, Token token) {
 		this.topic = topic;
 		this.token = token;
+	}
+
+	public static TopicToken create(Topic topic, Token token) {
+		return TopicToken.builder()
+			.topic(topic)
+			.token(token)
+			.build();
 	}
 }

--- a/src/main/java/com/example/ajouevent/service/BannerService.java
+++ b/src/main/java/com/example/ajouevent/service/BannerService.java
@@ -28,13 +28,13 @@ public class BannerService {
 	private final JsonParsingUtil jsonParsingUtil;
 
 	public BannerDto addBanner(BannerRequest bannerRequest) {
-		Banner banner = Banner.builder()
-			.imgUrl(bannerRequest.getImgUrl())
-			.siteUrl(bannerRequest.getSiteUrl())
-			.bannerOrder(bannerRequest.getBannerOrder())
-			.startDate(bannerRequest.getStartDate())
-			.endDate(bannerRequest.getEndDate())
-			.build();
+		Banner banner = Banner.create(
+			bannerRequest.getImgUrl(),
+			bannerRequest.getSiteUrl(),
+			bannerRequest.getBannerOrder(),
+			bannerRequest.getStartDate(),
+			bannerRequest.getEndDate()
+		);
 		bannerRepository.save(banner);
 
 		jsonParsingUtil.clearCache("Banners");

--- a/src/main/java/com/example/ajouevent/service/EventCommandService.java
+++ b/src/main/java/com/example/ajouevent/service/EventCommandService.java
@@ -74,17 +74,17 @@ public class EventCommandService {
 		Type type = Type.valueOf(noticeDto.getEnglishTopic().toUpperCase());
 		log.info("저장하는 타입 : " + type.getEnglishTopic());
 
-		ClubEvent clubEvent = ClubEvent.builder()
-			.title(noticeDto.getTitle())
-			.content(noticeDto.getContent())
-			.createdAt(LocalDateTime.now()) // 크롤링한 공지사항의 게시글 시간은 크롤링하는 당시 시간으로 설정
-			.url(noticeDto.getUrl())
-			.subject(noticeDto.getKoreanTopic())
-			.writer(noticeDto.getDepartment())
-			.type(type)
-			.likesCount(DEFAULT_LIKES_COUNT)
-			.viewCount(DEFAULT_VIEW_COUNT)
-			.build();
+		ClubEvent clubEvent = ClubEvent.create(
+			noticeDto.getTitle(),
+			noticeDto.getContent(),
+			noticeDto.getDepartment(),
+			LocalDateTime.now(),  // 크롤링한 공지사항의 게시글 시간은 크롤링하는 당시 시간으로 설정
+			noticeDto.getKoreanTopic(),
+			noticeDto.getUrl(),
+			type,
+			DEFAULT_LIKES_COUNT,
+			DEFAULT_VIEW_COUNT
+		);
 
 		log.info("크롤링한 공지사항 원래 url" + noticeDto.getUrl());
 
@@ -100,17 +100,11 @@ public class EventCommandService {
 		}
 
 		// -> payload에서 parsing에서 바로 가져올 수 있으면 좋음
-		List<ClubEventImage> clubEventImageList = new ArrayList<>();
-		for (String imageUrl : noticeDto.getImages()) {
-			ClubEventImage clubEventImage = ClubEventImage.builder()
-				.url(imageUrl)
-				.clubEvent(clubEvent)
-				.build();
-			clubEventImageList.add(clubEventImage);
-		}
+		List<ClubEventImage> clubEventImageList = noticeDto.getImages().stream()
+			.map(imageUrl -> ClubEventImage.create(imageUrl, clubEvent))
+			.toList();
 
-		clubEvent.setClubEventImageList(clubEventImageList);
-
+		clubEvent.assignImages(clubEventImageList);
 
 		// 각 업로드된 이미지의 URL을 사용하여 ClubEventImage를 생성하고, ClubEvent와 연관시킵니다.
 
@@ -133,7 +127,7 @@ public class EventCommandService {
 
 		// 구독자들의 읽음 상태를 '읽지 않음'으로 설정
 		for (TopicMember topicMember : topicMembers) {
-			topicMember.setRead(false);  // 읽음 상태를 읽지 않음으로 설정
+			topicMember.markAsUnread();
 		}
 
 		topicMemberBulkRepository.updateTopicMembers(topicMembers);
@@ -151,7 +145,7 @@ public class EventCommandService {
 
 				// 각 구독자의 읽음 상태를 '읽지 않음'으로 설정
 				for (KeywordMember keywordMember : keywordMembers) {
-					keywordMember.setRead(false);  // 읽음 상태를 읽지 않음으로 설정
+					keywordMember.markAsUnread();
 				}
 				keywordMemberBulkRepository.updateKeywordMembers(keywordMembers);
 			}
@@ -183,26 +177,22 @@ public class EventCommandService {
 			log.info("제공된 이미지가 없습니다.");
 		}
 
-		ClubEvent clubEvent = ClubEvent.builder()
-			.title(postEventDto.getTitle())
-			.content(postEventDto.getContent())
-			.url(postEventDto.getUrl())
-			.createdAt(LocalDateTime.now())
-			.writer(postEventDto.getWriter())
-			.subject(postEventDto.getSubject())
-			.type(postEventDto.getType())
-			.clubEventImageList(new ArrayList<>())
-			.likesCount(DEFAULT_LIKES_COUNT)
-			.viewCount(DEFAULT_VIEW_COUNT)
-			.build();
+		ClubEvent clubEvent = ClubEvent.create(
+			postEventDto.getTitle(),
+			postEventDto.getContent(),
+			postEventDto.getWriter(),
+			LocalDateTime.now(),
+			postEventDto.getSubject(),
+			postEventDto.getUrl(),
+			postEventDto.getType(),
+			DEFAULT_LIKES_COUNT,
+			DEFAULT_VIEW_COUNT
+		);
 
 		// 각 업로드된 이미지의 URL을 사용하여 ClubEventImage를 생성하고, ClubEvent와 연관시킵니다.
 		for (String postImage : postImages) {
 			log.info("S3에 올라간 이미지: " + postImage);
-			ClubEventImage clubEventImage = ClubEventImage.builder()
-				.url(postImage)
-				.clubEvent(clubEvent)
-				.build();
+			ClubEventImage clubEventImage = ClubEventImage.create(postImage, clubEvent);
 			clubEvent.getClubEventImageList().add(clubEventImage);
 		}
 
@@ -214,26 +204,22 @@ public class EventCommandService {
 	@Transactional
 	public void postEvent(PostEventDto postEventDto) {
 
-		ClubEvent clubEvent = ClubEvent.builder()
-			.title(postEventDto.getTitle())
-			.content(postEventDto.getContent())
-			.url(postEventDto.getUrl())
-			.createdAt(postEventDto.getEventDateTime())
-			.writer(postEventDto.getWriter())
-			.subject(postEventDto.getSubject())
-			.type(postEventDto.getType())
-			.clubEventImageList(new ArrayList<>())
-			.likesCount(DEFAULT_LIKES_COUNT)
-			.viewCount(DEFAULT_VIEW_COUNT)
-			.build();
+		ClubEvent clubEvent = ClubEvent.create(
+			postEventDto.getTitle(),
+			postEventDto.getContent(),
+			postEventDto.getWriter(),
+			postEventDto.getEventDateTime(),
+			postEventDto.getSubject(),
+			postEventDto.getUrl(),
+			postEventDto.getType(),
+			DEFAULT_LIKES_COUNT,
+			DEFAULT_VIEW_COUNT
+		);
 
 		// 프론트엔드에서 받은 이미지 URL 리스트를 처리
 		if (postEventDto.getImageUrls() != null) {
 			for (String imageUrl : postEventDto.getImageUrls()) {
-				ClubEventImage clubEventImage = ClubEventImage.builder()
-					.url(imageUrl)
-					.clubEvent(clubEvent)
-					.build();
+				ClubEventImage clubEventImage = ClubEventImage.create(imageUrl, clubEvent);
 				clubEvent.getClubEventImageList().add(clubEventImage);
 			}
 		}
@@ -355,10 +341,7 @@ public class EventCommandService {
 
 		// 새 이미지 추가
 		List<ClubEventImage> addedImages = toAddUrls.stream()
-			.map(url -> ClubEventImage.builder()
-				.url(url)
-				.clubEvent(clubEvent)
-				.build())
+			.map(url -> ClubEventImage.create(url, clubEvent))
 			.collect(Collectors.toList());
 
 		clubEventImageRepository.saveAll(addedImages);
@@ -407,11 +390,7 @@ public class EventCommandService {
 		if (images != null && !images.isEmpty()) {
 			for (MultipartFile image : images) {
 				String imageUrl = s3Upload.uploadFiles(image, "images");
-				ClubEventImage clubEventImage = ClubEventImage.builder()
-					.url(imageUrl)
-					.clubEvent(clubEvent)
-					.build();
-				updatedImages.add(clubEventImage);
+				updatedImages.add(ClubEventImage.create(imageUrl, clubEvent));
 			}
 			// Remove old images and add updated ones
 			clubEvent.getClubEventImageList().clear();

--- a/src/main/java/com/example/ajouevent/service/EventLikeService.java
+++ b/src/main/java/com/example/ajouevent/service/EventLikeService.java
@@ -59,10 +59,7 @@ public class EventLikeService {
 		}
 
 		// 이벤트를 사용자의 찜 목록에 추가
-		EventLike eventLike = EventLike.builder()
-			.clubEvent(clubEvent)
-			.member(member)
-			.build();
+		EventLike eventLike = EventLike.create(clubEvent, member);
 
 		// 게시글의 좋아요 수 증가
 		clubEvent.incrementLikes();

--- a/src/main/java/com/example/ajouevent/service/KeywordService.java
+++ b/src/main/java/com/example/ajouevent/service/KeywordService.java
@@ -74,12 +74,7 @@ public class KeywordService {
 			throw new CustomException(CustomErrorCode.MAX_KEYWORD_LIMIT_EXCEEDED);
 		}
 
-		KeywordMember keywordMember = KeywordMember.builder()
-			.keyword(keyword)
-			.member(member)
-			.isRead(false)
-			.lastReadAt(LocalDateTime.now())
-			.build();
+		KeywordMember keywordMember = KeywordMember.create(keyword, member);
 		keywordMemberRepository.save(keywordMember);
 
 		tokenSubscriptionService.subscribeTokenToKeyword(member, keyword);
@@ -90,12 +85,12 @@ public class KeywordService {
 	// 새로운 키워드 생성 메서드
 	private Keyword createNewTopic(KeywordRequest keywordRequest, String searchKeyword, String formattedKeyword, Topic topic) {
 		// 새로운 토픽 생성 로직
-		Keyword newKeyword = Keyword.builder()
-			.encodedKeyword(formattedKeyword)
-			.koreanKeyword(keywordRequest.getKoreanKeyword())
-			.searchKeyword(searchKeyword)
-			.topic(topic)
-			.build();
+		Keyword newKeyword = Keyword.create(
+			formattedKeyword,
+			keywordRequest.getKoreanKeyword(),
+			searchKeyword,
+			topic
+		);
 		keywordRepository.save(newKeyword);
 
 		keywordLogger.log("새로운 키워드 생성 : " + newKeyword.getKoreanKeyword());
@@ -152,8 +147,7 @@ public class KeywordService {
 		KeywordMember keywordMember = keywordMemberRepository.findByKeywordAndMember(keyword, member)
 			.orElseThrow(() -> new CustomException(CustomErrorCode.KEYWORD_NOT_FOUND));
 		if (keywordMember.isRead() == false) {
-			keywordMember.setRead(true);
-			keywordMember.setLastReadAt(LocalDateTime.now());
+			keywordMember.markAsRead();
 			keywordMemberRepository.save(keywordMember);
 		}
 	}

--- a/src/main/java/com/example/ajouevent/service/MemberService.java
+++ b/src/main/java/com/example/ajouevent/service/MemberService.java
@@ -67,13 +67,10 @@ public class MemberService {
 
 		String password = BCryptEncoder.encode(registerRequest.getPassword());
 
-		Member newMember = Member.builder()
-				.email(registerRequest.getEmail())
-				.major(registerRequest.getMajor())
-				// .phone(registerRequest.getPhone())
-				.name(registerRequest.getName())
-				.password(password)
-				.build();
+		Member newMember = Member.register(
+			registerRequest.getEmail(),
+			registerRequest.getName()
+		);
 
 		memberRepository.save(newMember);
 
@@ -88,8 +85,9 @@ public class MemberService {
 		Member member = memberRepository.findByEmail(principal.getName())
 			.orElseThrow(() -> new CustomException(CustomErrorCode.LOGIN_FAILED));
 
-		if (registerMemberInfoRequest.getMajor() != null) member.setMajor(registerMemberInfoRequest.getMajor());
-
+		if (registerMemberInfoRequest.getMajor() != null) {
+			member.changeMajor(registerMemberInfoRequest.getMajor());
+		}
 
 		memberRepository.save(member);
 
@@ -146,12 +144,12 @@ public class MemberService {
 
 		Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
 
-			MemberDto.MemberInfoDto memberInfoDto = MemberDto.MemberInfoDto.builder()
-				.memberId(member.getId())
-				.email(member.getEmail())
-				.password(member.getPassword())
-				.role(member.getRole())
-				.build();
+		MemberDto.MemberInfoDto memberInfoDto = MemberDto.MemberInfoDto.builder()
+			.memberId(member.getId())
+			.email(member.getEmail())
+			.password(member.getPassword())
+			.role(member.getRole())
+			.build();
 
 		String accessToken = jwtUtil.createAccessToken(memberInfoDto);
 
@@ -178,9 +176,7 @@ public class MemberService {
 	public String updateMemberInfo (MemberUpdateDto memberUpdateDto, Principal principal) {
 		Member member = memberRepository.findByEmail(principal.getName()).orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
 
-		if (memberUpdateDto.getMajor() != null) member.setMajor(memberUpdateDto.getMajor());
-		if (memberUpdateDto.getName() != null) member.setName(memberUpdateDto.getName());
-		if (memberUpdateDto.getPhone() != null) member.setPhone(memberUpdateDto.getPhone());
+		member.updateProfile(memberUpdateDto.getName(), memberUpdateDto.getMajor(), memberUpdateDto.getPhone());
 		memberRepository.save(member);
 		return "수정 완료";
 	}
@@ -224,10 +220,10 @@ public class MemberService {
 		if (memberOptional.isPresent()) {
 			member = memberOptional.get();
 		} else {
-			member = Member.builder()
-				.email(userInfoGetDto.getEmail())
-				.name(userInfoGetDto.getName())
-				.build();
+			member = Member.register(
+				userInfoGetDto.getEmail(),
+				userInfoGetDto.getName()
+			);
 
 			memberRepository.save(member);
 			isNewMember = true; // 새로 가입한 회원으로 설정
@@ -384,7 +380,7 @@ public class MemberService {
 		}
 
 		String newPassword = BCryptEncoder.encode(passwordDto.getNewPassword());
-		member.setPassword(newPassword);
+		member.changePassword(newPassword);
 		memberRepository.save(member);
 		return "비밀번호 변경 완료";
 	}
@@ -395,7 +391,7 @@ public class MemberService {
 			.orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
 
 		String newPassword = BCryptEncoder.encode(resetPasswordDto.getNewPassword());
-		member.setPassword(newPassword);
+		member.changePassword(newPassword);
 		memberRepository.save(member);
 		return "비밀번호 재설정 완료";
 	}
@@ -407,7 +403,8 @@ public class MemberService {
 		if (member == null)
 			throw new CustomException(CustomErrorCode.EVENT_NOT_FOUND);
 
-		member.setPassword(BCryptEncoder.encode(newPw));
+		String newPassword = BCryptEncoder.encode(newPw);
+		member.changePassword(newPassword);
 
 		try {
 			SMTPMsgDto smtpMsgDto = SMTPMsgDto.builder()

--- a/src/main/java/com/example/ajouevent/service/PushClusterService.java
+++ b/src/main/java/com/example/ajouevent/service/PushClusterService.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -54,27 +53,12 @@ public class PushClusterService {
 
 		JobStatus initialStatus = topicTokens.isEmpty() ? JobStatus.NONE : JobStatus.PENDING;
 
-		PushCluster cluster = PushCluster.builder()
-				.clubEvent(clubEvent)
-				.title(title)
-				.body(body)
-				.imageUrl(imageUrl)
-				.clickUrl(clickUrl)
-				.totalCount(topicTokens.size())
-				.jobStatus(initialStatus)
-				.registeredAt(LocalDateTime.now())
-				.topic(topic)
-				.build();
+		PushCluster cluster = PushCluster.createForTopic(clubEvent, topic, title, body, imageUrl, clickUrl, topicTokens.size(), initialStatus);
 		pushClusterRepository.save(cluster);
 
 		List<PushClusterToken> clusterTokens = topicTokens.stream()
-				.map(token -> PushClusterToken.builder()
-						.pushCluster(cluster)
-						.token(token.getToken()) // TopicToken에 연결된 Token 가져오기
-						.jobStatus(JobStatus.PENDING) // 초기 상태: PENDING
-						.requestTime(LocalDateTime.now())
-						.build())
-				.toList();
+			.map(token -> PushClusterToken.create(cluster, token.getToken()))
+			.toList();
 		pushClusterTokenBulkRepository.saveAll(clusterTokens);
 
 		return cluster;
@@ -97,28 +81,12 @@ public class PushClusterService {
 			if (dto.getTitle().contains(keyword.getKoreanKeyword())) {
 				List<KeywordToken> keywordTokens = keywordTokenRepository.findKeywordTokensWithTokenByKeyword(keyword);
 				JobStatus initialStatus = keywordTokens.isEmpty() ? JobStatus.NONE : JobStatus.PENDING;
-				PushCluster cluster = PushCluster.builder()
-						.clubEvent(clubEvent)
-						.topic(topic)
-						.keyword(keyword)
-						.title(title)
-						.body(body)
-						.imageUrl(imageUrl)
-						.clickUrl(clickUrl)
-						.totalCount(keywordTokens.size())
-						.jobStatus(initialStatus)
-						.registeredAt(LocalDateTime.now())
-						.build();
+				PushCluster cluster = PushCluster.createForKeyword(clubEvent, topic, keyword, title, body, imageUrl, clickUrl, keywordTokens.size(), initialStatus);
 				pushClusterRepository.save(cluster);
 
 				List<PushClusterToken> clusterTokens = keywordTokens.stream()
-						.map(token -> PushClusterToken.builder()
-								.pushCluster(cluster)
-								.token(token.getToken()) // KeywordToken에 연결된 Token 가져오기
-								.jobStatus(JobStatus.PENDING) // 초기 상태: PENDING
-								.requestTime(LocalDateTime.now())
-								.build())
-						.toList();
+					.map(kt -> PushClusterToken.create(cluster, kt.getToken()))
+					.toList();
 				pushClusterTokenBulkRepository.saveAll(clusterTokens);
 
 				clusters.add(cluster);
@@ -225,8 +193,8 @@ public class PushClusterService {
 			int receivedCount = clusterData.getOrDefault("received", 0);
 			int clickedCount = clusterData.getOrDefault("clicked", 0);
 
-			pushCluster.setReceivedCount(pushCluster.getReceivedCount() + receivedCount);
-			pushCluster.setClickedCount(pushCluster.getClickedCount() + clickedCount);
+			pushCluster.addReceivedCount(receivedCount);
+			pushCluster.addClickedCount(clickedCount);
 
 			pushClustersToUpdate.add(pushCluster);
 

--- a/src/main/java/com/example/ajouevent/service/PushNotificationService.java
+++ b/src/main/java/com/example/ajouevent/service/PushNotificationService.java
@@ -169,18 +169,8 @@ public class PushNotificationService {
 		List<TopicMember> topicMembers = topicMemberRepository.findByTopicWithNotificationEnabledAndTokens(cluster.getTopic());
 
 		List<PushNotification> notifications = topicMembers.stream()
-				.map(member -> PushNotification.builder()
-						.pushCluster(cluster)
-						.member(member.getMember())
-						.topic(cluster.getTopic())
-						.title(cluster.getTitle())
-						.body(cluster.getBody())
-						.imageUrl(cluster.getImageUrl())
-						.clickUrl(cluster.getClickUrl())
-						.notificationType(NotificationType.TOPIC)
-						.notifiedAt(LocalDateTime.now())
-						.build())
-				.toList();
+			.map(member -> PushNotification.createForTopic(cluster, member.getMember()))
+			.toList();
 		pushNotificationBulkRepository.saveAll(notifications);
 	}
 
@@ -189,19 +179,8 @@ public class PushNotificationService {
 		for (PushCluster cluster : clusters) {
 			List<KeywordMember> keywordMembers = keywordMemberRepository.findByKeyword(cluster.getKeyword());
 			List<PushNotification> notifications = keywordMembers.stream()
-					.map(member -> PushNotification.builder()
-							.pushCluster(cluster)
-							.member(member.getMember())
-							.keyword(cluster.getKeyword())
-							.topic(cluster.getTopic())
-							.title(cluster.getTitle())
-							.body(cluster.getBody())
-							.imageUrl(cluster.getImageUrl())
-							.clickUrl(cluster.getClickUrl())
-							.notificationType(NotificationType.KEYWORD)
-							.notifiedAt(LocalDateTime.now())
-							.build())
-					.toList();
+				.map(member -> PushNotification.createForKeyword(cluster, member.getMember()))
+				.toList();
 			pushNotificationBulkRepository.saveAll(notifications);
 		}
 	}

--- a/src/main/java/com/example/ajouevent/service/RedisService.java
+++ b/src/main/java/com/example/ajouevent/service/RedisService.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RedisService {
 	private static final Long clientAddressPostRequestWriteExpireDurationSec = 86400L;
 	private final StringRedisTemplate stringRedisTemplate;
-	private static final Long crawlingTokenExpireDurationSec = 90000L; // 토큰 TTL (1일+a)
+	private static final Long crawlingTokenExpireDurationSec = 315_360_000L; // 토큰 TTL (10년)
 
 	public boolean isFirstIpRequest(String clientAddress, Long eventId, Object reference) {
 		String key = generateKey(clientAddress, eventId, reference);

--- a/src/main/java/com/example/ajouevent/service/TokenService.java
+++ b/src/main/java/com/example/ajouevent/service/TokenService.java
@@ -72,17 +72,12 @@ public class TokenService {
 		Optional<Token> existingToken = tokenRepository.findByTokenValueAndMember(loginRequest.getFcmToken(), member);
 		if (existingToken.isPresent()) {
 			Token token = existingToken.get();
-			token.setExpirationDate(LocalDate.now().plusWeeks(TOKEN_EXPIRATION_WEEKS));
+			token.extendExpiration(TOKEN_EXPIRATION_WEEKS);
 			tokenRepository.save(token);
 			return;
 		}
 
-		Token token = Token.builder()
-			.tokenValue(loginRequest.getFcmToken())
-			.member(member)
-			.expirationDate(LocalDate.now().plusWeeks(TOKEN_EXPIRATION_WEEKS))
-			.isDeleted(false)
-			.build();
+		Token token = Token.create(loginRequest.getFcmToken(), member, TOKEN_EXPIRATION_WEEKS);
 		tokenRepository.save(token);
 
 		List<Topic> subscribedTopics = topicQueryService.getSubscribedTopics(member);

--- a/src/main/java/com/example/ajouevent/service/TokenSubscriptionService.java
+++ b/src/main/java/com/example/ajouevent/service/TokenSubscriptionService.java
@@ -39,7 +39,7 @@ public class TokenSubscriptionService {
 	public void subscribeTokenToTopic(Member member, Topic topic) {
 		List<Token> tokens = getTokensForMember(member);
 		List<TopicToken> topicTokens = tokens.stream()
-			.map(token -> new TopicToken(topic, token))
+			.map(token -> TopicToken.create(topic, token))
 			.toList();
 		topicTokenBulkRepository.saveAll(topicTokens);
 	}
@@ -49,7 +49,7 @@ public class TokenSubscriptionService {
 	public void subscribeTokenToKeyword(Member member, Keyword keyword) {
 		List<Token> tokens = getTokensForMember(member);
 		List<KeywordToken> keywordTokens = tokens.stream()
-			.map(token -> new KeywordToken(keyword, token))
+			.map(token -> KeywordToken.create(keyword, token))
 			.toList();
 		keywordTokenBulkRepository.saveAll(keywordTokens);
 	}
@@ -72,7 +72,7 @@ public class TokenSubscriptionService {
 	@Transactional
 	public void subscribeTokensToTopics(List<Topic> topics, Token token) {
 		List<TopicToken> topicTokens = topics.stream()
-			.map(topic -> new TopicToken(topic, token))
+			.map(topic -> TopicToken.create(topic, token))
 			.toList();
 		topicTokenBulkRepository.saveAll(topicTokens);
 	}
@@ -81,7 +81,7 @@ public class TokenSubscriptionService {
 	@Transactional
 	public void subscribeTokensToKeywords(List<Keyword> keywords, Token token) {
 		List<KeywordToken> keywordTokens = keywords.stream()
-			.map(keyword -> new KeywordToken(keyword, token))
+			.map(keyword -> KeywordToken.create(keyword, token))
 			.toList();
 		keywordTokenBulkRepository.saveAll(keywordTokens);
 	}

--- a/src/main/java/com/example/ajouevent/service/TopicService.java
+++ b/src/main/java/com/example/ajouevent/service/TopicService.java
@@ -53,13 +53,7 @@ public class TopicService {
 		topicLogger.log(topic.getDepartment() + "토픽 구독");
 		topicLogger.log("멤버 이메일 : " + memberEmail);
 
-		TopicMember topicMember = TopicMember.builder()
-			.topic(topic)
-			.member(member)
-			.isRead(false)
-			.lastReadAt(LocalDateTime.now())
-			.receiveNotification(true)
-			.build();
+		TopicMember topicMember = TopicMember.create(member, topic);
 		topicMemberRepository.save(topicMember);
 
 		//  SubscriptionService를 호출하여 Token과 Topic 매핑
@@ -121,7 +115,7 @@ public class TopicService {
 		TopicMember topicMember = topicMemberRepository.findByMemberAndTopic(member, topic)
 			.orElseThrow(() -> new CustomException(CustomErrorCode.SUBSCRIBE_FAILED));
 
-		topicMember.setReceiveNotification(request.isReceiveNotification());
+		topicMember.changeReceiveNotification(request.isReceiveNotification());
 	}
 
 	@Transactional
@@ -135,8 +129,7 @@ public class TopicService {
 		Optional<TopicMember> optionalTopicMember = topicMemberRepository.findByMemberAndTopic(member, topic);
 		if (optionalTopicMember.isPresent()) { // 사용자가 구독하고 있는 경우만 읽음 상태 갱신
 			TopicMember topicMember = optionalTopicMember.get();
-			topicMember.setRead(true);
-			topicMember.setLastReadAt(LocalDateTime.now());
+			topicMember.markAsRead();
 			topicMemberRepository.save(topicMember);
 		}
 	}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#105)

## 💻 작업 내용
- [x] 생성자 대신 create 정적 팩토리 메서드 도입으로 의미 있는 객체 생성 방식 제공
- [x] @Builder를 private 생성자에만 적용하여 유연한 객체 생성 지원
- [x] @NoArgsConstructor(access = PROTECTED) 적용하여 무분별한 객체 생성을 방지
- [x] @Table을 명시해 DB 테이블 이름 명확히 지정
- [x] 명확한 도메인 모델링 강화를 위한 setter 제거

## 💬 리뷰 요구사항 (선택)

> 리뷰 시 중점적으로 확인해 주셨으면 하는 부분입니다.
