### PR TITLE
[Refactor] Redis 장애 대응 로직 및 Cache Fallback 구조 적용

### DIFF
--- a/src/main/java/com/example/ajouevent/config/RedisConfig.java
+++ b/src/main/java/com/example/ajouevent/config/RedisConfig.java
@@ -6,10 +6,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 @ComponentScan
@@ -23,7 +27,14 @@ public class RedisConfig {
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(host, port);
+		RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
+
+		// Lettuce 클라이언트 타임아웃 설정 추가
+		LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+			.commandTimeout(Duration.ofMillis(500)) // 커맨드 타임아웃 설정
+			.build();
+
+		return new LettuceConnectionFactory(redisStandaloneConfiguration, clientConfig);
 	}
 
 	// StringRedisSerializer

--- a/src/main/java/com/example/ajouevent/infrastructure/cache/CacheRepository.java
+++ b/src/main/java/com/example/ajouevent/infrastructure/cache/CacheRepository.java
@@ -1,0 +1,15 @@
+package com.example.ajouevent.infrastructure.cache;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+public interface CacheRepository {
+
+	<T> Optional<T> get(String key, TypeReference<T> typeRef);
+
+	void set(String key, Object value, long timeout, TimeUnit timeUnit);
+
+	void delete(String key);
+}

--- a/src/main/java/com/example/ajouevent/infrastructure/cache/RedisCacheRepositoryImpl.java
+++ b/src/main/java/com/example/ajouevent/infrastructure/cache/RedisCacheRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.example.ajouevent.infrastructure.cache;
+
+import java.util.Optional;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+@Repository
+public class RedisCacheRepositoryImpl implements CacheRepository {
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public <T> Optional<T> get(String key, TypeReference<T> typeRef) {
+		try {
+			String json = redisTemplate.opsForValue().get(key);
+			if (json == null) {
+				return Optional.empty();
+			}
+			return Optional.of(objectMapper.readValue(json, typeRef));
+		} catch (Exception e) {
+			log.error("🔌 Redis get 실패 (key: {}): {}", key, e.getMessage());
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public void set(String key, Object value, long timeout, TimeUnit timeUnit) {
+		if (value == null) { // null 캐싱 금지
+			log.debug("⚠️ null 값은 캐싱하지 않음 (key: {})", key);
+			return;
+		}
+		try {
+			String json = objectMapper.writeValueAsString(value);
+			redisTemplate.opsForValue().set(key, json, timeout, timeUnit);
+		} catch (Exception e) {
+			log.error("🔌 Redis set 실패 (key: {}): {}", key, e.getMessage());
+		}
+	}
+
+	@Override
+	public void delete(String key) {
+		try {
+			redisTemplate.delete(key);
+		} catch (Exception e) {
+			log.error("🔌 Redis delete 실패 (key: {}): {}", key, e.getMessage());
+		}
+	}
+}

--- a/src/test/java/com/example/ajouevent/infrastructure/cache/RedisCacheRepositoryImplTest.java
+++ b/src/test/java/com/example/ajouevent/infrastructure/cache/RedisCacheRepositoryImplTest.java
@@ -1,0 +1,108 @@
+package com.example.ajouevent.infrastructure.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+
+class RedisCacheRepositoryImplTest {
+
+	private RedisCacheRepositoryImpl redisCacheRepositoryImpl;
+
+	private RedisTemplate<String, String> redisTemplate;
+	private ObjectMapper objectMapper;
+	private ValueOperations<String, String> valueOperations;
+
+	@BeforeEach
+	void setUp() {
+		redisTemplate = mock(RedisTemplate.class);
+		objectMapper = spy(new ObjectMapper());
+		valueOperations = mock(ValueOperations.class);
+
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+		redisCacheRepositoryImpl = new RedisCacheRepositoryImpl(redisTemplate, objectMapper);
+	}
+
+	@Test
+	@DisplayName("캐시에서 값을 조회할 수 있다")
+	void get() {
+		// given
+		String key = "testKey";
+		String json = "\"testValue\""; // String 타입 JSON 직렬화 결과
+		when(valueOperations.get(key)).thenReturn(json);
+
+		// when
+		Optional<String> result = redisCacheRepositoryImpl.get(key, new TypeReference<>() {});
+
+		// then
+		assertThat(result).isPresent().contains("testValue");
+		verify(valueOperations).get(key);
+	}
+
+	@Test
+	@DisplayName("캐시에 값을 저장할 수 있다")
+	void set() throws Exception {
+		// given
+		String key = "testKey";
+		String value = "testValue";
+		String json = objectMapper.writeValueAsString(value);
+
+		// when
+		redisCacheRepositoryImpl.set(key, value, 60, TimeUnit.SECONDS);
+
+		// then
+		verify(valueOperations).set(key, json, 60, TimeUnit.SECONDS);
+	}
+
+	@Test
+	@DisplayName("캐시에서 키를 삭제할 수 있다")
+	void delete() {
+		// given
+		String key = "testKey";
+
+		// when
+		redisCacheRepositoryImpl.delete(key);
+
+		// then
+		verify(redisTemplate).delete(key);
+	}
+
+	@Test
+	@DisplayName("Redis 연결 실패 시 get()은 Optional.empty()를 반환한다")
+	void get_whenRedisFails_returnsEmptyOptional() {
+		// given
+		String key = "failKey";
+		when(valueOperations.get(key)).thenThrow(new RedisConnectionFailureException("Redis down"));
+
+		// when
+		Optional<String> result = redisCacheRepositoryImpl.get(key, new TypeReference<>() {});
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Redis 연결 실패 시 set()은 예외를 던지지 않는다")
+	void set_whenRedisFails_doesNotThrow() {
+		// given
+		String key = "failKey";
+		String value = "value";
+		doThrow(new RedisConnectionFailureException("Redis down")).when(valueOperations)
+			.set(anyString(), anyString(), anyLong(), any());
+
+		// when & then
+		redisCacheRepositoryImpl.set(key, value, 30, TimeUnit.SECONDS); // 예외 없어야 성공
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#108)

## 💻 작업 내용
- [x] Redis get, set, delete에서 예외 발생 시 로그만 남기고 예외 전파하지 않도록 변경
- [x] Redis 장애가 전체 서비스 장애로 확산되지 않도록 방어

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
